### PR TITLE
refactor(domain): replace regex with precise manual domain validation

### DIFF
--- a/src/nawala/checker_test.go
+++ b/src/nawala/checker_test.go
@@ -7,6 +7,7 @@ package nawala_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +34,9 @@ func TestIsValidDomain(t *testing.T) {
 		{"invalid special chars", "exam!ple.com", false},
 		{"invalid spaces", "example .com", false},
 		{"invalid too short label", "a.com", false},
+		{"invalid TLD with digits", "example.c0m", false},
+		{"invalid TLD with hyphen", "example.c-m", false},
+		{"invalid label too long", "example." + strings.Repeat("a", 64) + ".com", false},
 	}
 
 	for _, tt := range tests {

--- a/src/nawala/domain.go
+++ b/src/nawala/domain.go
@@ -5,17 +5,57 @@
 
 package nawala
 
-import (
-	"regexp"
-	"strings"
-)
-
-// domainRegex validates domain names.
-var domainRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$`)
+import "strings"
 
 // IsValidDomain reports whether domain is a syntactically valid domain name.
+//
+// A valid domain must have at least two labels separated by dots,
+// each label must be 2-63 characters long, contain only ASCII
+// letters, digits, or hyphens, and must not start or end with a hyphen.
+// The TLD (last label) must be at least 2 characters and contain only letters.
 func IsValidDomain(domain string) bool {
-	return domainRegex.MatchString(domain)
+	if domain == "" {
+		return false
+	}
+
+	labels := strings.Split(domain, ".")
+	if len(labels) < 2 {
+		return false
+	}
+
+	for i, label := range labels {
+		if len(label) < 2 || len(label) > 63 {
+			return false
+		}
+
+		// Labels must not start or end with a hyphen.
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+
+		isTLD := i == len(labels)-1
+
+		for _, c := range label {
+			switch {
+			case c >= 'a' && c <= 'z':
+				// ok
+			case c >= 'A' && c <= 'Z':
+				// ok
+			case c >= '0' && c <= '9':
+				if isTLD {
+					return false // TLD must be letters only.
+				}
+			case c == '-':
+				if isTLD {
+					return false // TLD must be letters only.
+				}
+			default:
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 // normalizeDomain lowercases and trims whitespace from a domain name.


### PR DESCRIPTION
- [+] Remove regex dependency for validation
- [+] Add checks for label count (>=2), lengths (2-63 chars), no leading/trailing hyphens
- [+] Enforce TLD rules: letters only, no digits or hyphens
- [+] Update function docs with detailed validation rules