### PR TITLE
refactor(nawala): improve domain validation per RFC 1035

### DIFF
--- a/src/nawala/checker_test.go
+++ b/src/nawala/checker_test.go
@@ -33,7 +33,7 @@ func TestIsValidDomain(t *testing.T) {
 		{"invalid ends with hyphen", "example-.com", false},
 		{"invalid special chars", "exam!ple.com", false},
 		{"invalid spaces", "example .com", false},
-		{"invalid too short label", "a.com", false},
+		{"valid short label", "a.com", true},
 		{"invalid TLD with digits", "example.c0m", false},
 		{"invalid TLD with hyphen", "example.c-m", false},
 		{"invalid label too long", "example." + strings.Repeat("a", 64) + ".com", false},

--- a/src/nawala/domain.go
+++ b/src/nawala/domain.go
@@ -76,7 +76,7 @@ func isValidTLD(label string) bool {
 	}
 
 	// Check for Punycode TLD (starts with xn--)
-	if len(label) >= 4 && strings.EqualFold(label[:4], "xn--") {
+	if len(label) > 4 && strings.EqualFold(label[:4], "xn--") {
 		// Punycode TLDs can contain digits and hyphens (standard hostname rules apply)
 		// We fall through to the general check below
 		return true

--- a/src/nawala/domain.go
+++ b/src/nawala/domain.go
@@ -77,8 +77,7 @@ func isValidTLD(label string) bool {
 
 	// Check for Punycode TLD (starts with xn--)
 	if len(label) > 4 && strings.EqualFold(label[:4], "xn--") {
-		// Punycode TLDs can contain digits and hyphens (standard hostname rules apply)
-		// We fall through to the general check below
+		// Punycode TLDs follow standard hostname rules (already validated by isValidLabel).
 		return true
 	}
 

--- a/src/nawala/domain_test.go
+++ b/src/nawala/domain_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 H0llyW00dzZ All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+package nawala
+
+import (
+	"testing"
+)
+
+func TestIsValidDomain(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain string
+		want   bool
+	}{
+		// Valid domains
+		{"standard domain", "example.com", true},
+		{"subdomain", "www.example.com", true},
+		{"single char label", "x.com", true},
+		{"single char subdomain", "a.b.co", true},
+		{"punycode domain", "xn--p1ai.ru", true},
+		{"punycode TLD", "example.xn--p1ai", true},
+		{"numeric label", "123.com", true},
+		{"hyphenated label", "ex-ample.com", true},
+		{"case insensitive", "EXAMPLE.COM", true},
+		{"FQDN with trailing dot", "example.com.", true},
+
+		// Invalid domains
+		{"empty string", "", false},
+		{"no TLD", "localhost", false},
+		{"start with hyphen", "-example.com", false},
+		{"end with hyphen", "example-.com", false},
+		{"consecutive dots", "example..com", false},
+		{"start with dot", ".example.com", false},
+		{"spaces", "example .com", false},
+		{"invalid char", "exa_mple.com", false}, // underscores not allowed in hostnames usually, though technically valid in DNS, we stick to hostname rules here as per original intent
+		{"too long label", "thislabeliswaytoolongandshoulddefinitelyfailbecausethelimitissixtythreecharacters.com", false},
+		{"TLD numeric", "example.123", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidDomain(tt.domain); got != tt.want {
+				t.Errorf("IsValidDomain(%q) = %v, want %v", tt.domain, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeDomain(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Example.Com", "example.com"},
+		{"  example.com  ", "example.com"},
+		{"EXAMPLE.COM", "example.com"},
+	}
+
+	for _, tt := range tests {
+		if got := normalizeDomain(tt.input); got != tt.want {
+			t.Errorf("normalizeDomain(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/src/nawala/domain_test.go
+++ b/src/nawala/domain_test.go
@@ -38,6 +38,12 @@ func TestIsValidDomain(t *testing.T) {
 		{"invalid char", "exa_mple.com", false}, // underscores not allowed in hostnames usually, though technically valid in DNS, we stick to hostname rules here as per original intent
 		{"too long label", "thislabeliswaytoolongandshoulddefinitelyfailbecausethelimitissixtythreecharacters.com", false},
 		{"TLD numeric", "example.123", false},
+		{"mixed case punycode TLD", "example.Xn--P1ai", true},
+		{"unicode characters", "example.рф", false}, // we only support ASCII/Punycode
+		{"underscore in label", "exa_mple.com", false},
+		{"underscore in TLD", "example.c_m", false},
+		{"trailing dot with space", "example.com. ", false},
+		{"double trailing dot", "example.com..", false},
 	}
 
 	for _, tt := range tests {

--- a/src/nawala/domain_test.go
+++ b/src/nawala/domain_test.go
@@ -42,6 +42,8 @@ func TestIsValidDomain(t *testing.T) {
 		{"unicode characters", "example.рф", false}, // we only support ASCII/Punycode
 		{"underscore in label", "exa_mple.com", false},
 		{"underscore in TLD", "example.c_m", false},
+		{"punycode prefix only", "example.xn--", false},
+		{"punycode prefix only case insensitive", "example.XN--", false},
 		{"trailing dot with space", "example.com. ", false},
 		{"double trailing dot", "example.com..", false},
 	}


### PR DESCRIPTION
- [+] Allow 1-63 character labels (including single-char) and enforce total domain length <=255
- [+] Add special TLD handling: >=2 chars, letters-only for standard or Punycode (xn--) support
- [+] Trim trailing dot for FQDN validation
- [+] Add comprehensive domain_test.go with IsValidDomain and normalizeDomain tests
- [+] Update checker_test.go to mark "a.com" as valid short label