### PR TITLE
Improve concurrency & cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ c := nawala.New(
         Keyword:   "blocked",
         QueryType: "A",
     }),
+
+    // Limit concurrent checks to 50 goroutines.
+    nawala.WithConcurrency(50),
 )
 ```
 
@@ -98,6 +101,7 @@ c := nawala.New(
 | `WithMaxRetries(n)` | `2` | Max retry attempts per query (total = n+1) |
 | `WithCacheTTL(d)` | `5m` | TTL for the built-in in-memory cache |
 | `WithCache(c)` | in-memory | Custom `Cache` implementation (pass `nil` to disable) |
+| `WithConcurrency(n)` | `100` | Max concurrent DNS checks (semaphore size) |
 | `WithServer(s)` | — | Add or replace a single DNS server |
 | `WithServers(s)` | Nawala defaults | Replace all DNS servers |
 

--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -8,6 +8,8 @@ package nawala
 import (
 	"context"
 	"net"
+	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -174,7 +176,7 @@ func TestFailover(t *testing.T) {
 	c := New(
 		WithServers([]DNSServer{
 			{Address: "127.0.0.1:19998", Keyword: "internetpositif", QueryType: "A"}, // unreachable
-			{Address: goodAddr, Keyword: "internetpositif", QueryType: "A"},           // working
+			{Address: goodAddr, Keyword: "internetpositif", QueryType: "A"},          // working
 		}),
 		WithTimeout(500*time.Millisecond),
 		WithMaxRetries(0),
@@ -230,7 +232,7 @@ func TestQueryWithRetriesSuccess(t *testing.T) {
 	defer cleanup()
 
 	c := New(
-		WithTimeout(5 * time.Second),
+		WithTimeout(5*time.Second),
 		WithMaxRetries(2),
 	)
 
@@ -357,4 +359,72 @@ func TestDNSStatusNoServers(t *testing.T) {
 
 	_, err := c.DNSStatus(ctx)
 	assert.ErrorIs(t, err, ErrNoDNSServers)
+}
+
+func TestCheckConcurrencyLimit(t *testing.T) {
+	// This test verifies that we don't spawn a goroutine for every domain
+	// immediately, but strictly bound it by the semaphore size (100).
+
+	// Create a slow mock server to ensure goroutines stack up.
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		time.Sleep(100 * time.Millisecond) // Slow response
+		m := new(dns.Msg)
+		m.SetReply(r)
+		_ = w.WriteMsg(m)
+	})
+	addr, cleanup := startTestDNSServer(t, handler)
+	defer cleanup()
+
+	c := New(
+		WithServers([]DNSServer{
+			{Address: addr, Keyword: "test", QueryType: "A"},
+		}),
+		WithTimeout(1*time.Second),
+	)
+
+	ctx := context.Background()
+	count := 500 // Significantly more than semaphore size (100)
+	domains := make([]string, count)
+	for i := range domains {
+		domains[i] = "example.com"
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Measure baseline goroutines
+	startGoroutines := runtime.NumGoroutine()
+
+	go func() {
+		defer wg.Done()
+		_, _ = c.Check(ctx, domains...)
+	}()
+
+	// Give time for the loop to spin up
+	time.Sleep(100 * time.Millisecond)
+
+	currentGoroutines := runtime.NumGoroutine()
+	totalSpawned := currentGoroutines - startGoroutines
+
+	// With the fix:
+	// - 100 workers (max semaphore)
+	// - 100 internal DNS goroutines (hypothetically)
+	// - 1 Check goroutine
+	// Total ~201.
+	//
+	// Without the fix:
+	// - 500 workers
+	// - 100 internal DNS goroutines
+	// - 1 Check goroutine
+	// Total ~601.
+	//
+	// We set threshold to 400 to safely distinguish.
+	t.Logf("Goroutines: start=%d, current=%d, delta=%d", startGoroutines, currentGoroutines, totalSpawned)
+
+	if totalSpawned > 400 {
+		t.Errorf("Too many goroutines spawned! Expected around 200-250, got %d. This indicates unbounded concurrency spawning.", totalSpawned)
+	}
+
+	// Wait for cleanup
+	wg.Wait()
 }

--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -428,3 +428,28 @@ func TestCheckConcurrencyLimit(t *testing.T) {
 	// Wait for cleanup
 	wg.Wait()
 }
+
+func TestWithConcurrency(t *testing.T) {
+	// Test default concurrency
+	c := New()
+	if c.concurrency != defaultConcurrency {
+		t.Errorf("expected default concurrency %d, got %d", defaultConcurrency, c.concurrency)
+	}
+
+	// Test custom concurrency
+	c = New(WithConcurrency(50))
+	if c.concurrency != 50 {
+		t.Errorf("expected concurrency 50, got %d", c.concurrency)
+	}
+
+	// Test invalid concurrency (should be ignored and remain default)
+	c = New(WithConcurrency(0))
+	if c.concurrency != defaultConcurrency {
+		t.Errorf("expected concurrency %d, got %d", defaultConcurrency, c.concurrency)
+	}
+
+	c = New(WithConcurrency(-1))
+	if c.concurrency != defaultConcurrency {
+		t.Errorf("expected concurrency %d, got %d", defaultConcurrency, c.concurrency)
+	}
+}

--- a/src/nawala/dns.go
+++ b/src/nawala/dns.go
@@ -43,15 +43,10 @@ func parseQueryType(qtype string) uint16 {
 
 // queryDNS sends a DNS query for the given domain to the specified server.
 // It respects context cancellation and the configured timeout.
-func queryDNS(ctx context.Context, domain, server string, qtype uint16, timeout time.Duration) (*dns.Msg, error) {
+func queryDNS(ctx context.Context, client *dns.Client, domain, server string, qtype uint16) (*dns.Msg, error) {
 	msg := new(dns.Msg)
 	msg.SetQuestion(dns.Fqdn(domain), qtype)
 	msg.RecursionDesired = true
-
-	client := &dns.Client{
-		Timeout: timeout,
-		Net:     "udp",
-	}
 
 	// Ensure server has port.
 	if !strings.Contains(server, ":") {
@@ -112,10 +107,10 @@ func containsKeyword(msg *dns.Msg, keyword string) bool {
 
 // checkDNSHealth performs a health check on a single DNS server by
 // resolving "google.com" and measuring the latency.
-func checkDNSHealth(ctx context.Context, server string, timeout time.Duration) ServerStatus {
+func checkDNSHealth(ctx context.Context, client *dns.Client, server string) ServerStatus {
 	start := time.Now()
 
-	resp, err := queryDNS(ctx, "google.com", server, dns.TypeA, timeout)
+	resp, err := queryDNS(ctx, client, "google.com", server, dns.TypeA)
 	latency := time.Since(start).Milliseconds()
 
 	if err != nil {

--- a/src/nawala/option.go
+++ b/src/nawala/option.go
@@ -66,3 +66,13 @@ func WithCacheTTL(d time.Duration) Option {
 		c.cacheTTL = d
 	}
 }
+
+// WithConcurrency sets the maximum number of concurrent DNS checks.
+// The default is 100.
+func WithConcurrency(n int) Option {
+	return func(c *Checker) {
+		if n > 0 {
+			c.concurrency = n
+		}
+	}
+}


### PR DESCRIPTION
- [+] Add shared `dns.Client` to `Checker` for connection reuse across queries
- [+] Introduce semaphore to cap concurrent domain checks at 100 goroutines
- [+] Implement double-checked locking in cache eviction for thread safety
- [+] Cap exponential backoff at 30s in retries
- [+] Update `queryDNS` and `checkDNSHealth` signatures to use shared client
- [+] Adjust tests to match new function signatures