### PR TITLE
style: fix formatting, whitespace, and indentation

### DIFF
--- a/examples/custom/main.go
+++ b/examples/custom/main.go
@@ -30,13 +30,13 @@ func main() {
 		}),
 
 		// Increase timeout for slow networks.
-		nawala.WithTimeout(15 * time.Second),
+		nawala.WithTimeout(15*time.Second),
 
 		// Allow more retries.
 		nawala.WithMaxRetries(3),
 
 		// Cache results for 10 minutes.
-		nawala.WithCacheTTL(10 * time.Minute),
+		nawala.WithCacheTTL(10*time.Minute),
 	)
 
 	ctx := context.Background()

--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -454,7 +454,7 @@ func TestWithConcurrency(t *testing.T) {
 }
 
 func TestCheckRaceCondition(t *testing.T) {
-	// Start a slow DNS server to ensure goroutines are still running 
+	// Start a slow DNS server to ensure goroutines are still running
 	// when we cancel the context.
 	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
 		time.Sleep(50 * time.Millisecond) // Simulate delay
@@ -475,7 +475,7 @@ func TestCheckRaceCondition(t *testing.T) {
 
 	// Create a context that we can cancel
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	// Check many domains to ensure we have active goroutines
 	// Must exceed default concurrency (100) to ensure the loop blocks on semaphore
 	// and is still running when we cancel.
@@ -498,8 +498,8 @@ func TestCheckRaceCondition(t *testing.T) {
 
 	// Let it start spawning goroutines
 	time.Sleep(10 * time.Millisecond)
-	
-	// CANCEL while it's running! 
+
+	// CANCEL while it's running!
 	cancel()
 
 	<-done

--- a/src/nawala/dns_test.go
+++ b/src/nawala/dns_test.go
@@ -255,7 +255,7 @@ func TestCheckDNSHealth(t *testing.T) {
 		assert.GreaterOrEqual(t, status.LatencyMs, int64(0))
 	})
 
-		t.Run("unreachable server", func(t *testing.T) {
+	t.Run("unreachable server", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 


### PR DESCRIPTION
- [+] Remove spaces around multiplication in time literals in examples/custom/main.go
- [+] Normalize comments and whitespace in src/nawala/checker_internal_test.go
- [+] Fix indentation of t.Run in src/nawala/dns_test.go