### PR TITLE
feat(nawala): add custom DNS client option and build tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ tmp/
 # Project build
 bin
 changelog.md
+coverage.txt
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 H0llyW00dzZ All rights reserved.
+#
+# By accessing or using this software, you agree to be bound by the terms
+# of the License Agreement, which you can find at LICENSE files.
+
+.PHONY: test test-short test-cover test-verbose build clean
+
+# Run tests with race detector (mirrors CI).
+test:
+	go test -race ./src/...
+
+# Run tests with verbose output and race detector.
+test-verbose:
+	go test -v -race ./src/...
+
+# Run tests with coverage report and race detector (same as CI).
+test-cover:
+	go test -v -race -coverprofile=coverage.txt -covermode=atomic ./src/...
+	@echo ""
+	@echo "Coverage report written to coverage.txt"
+	@echo "View in browser: go tool cover -html=coverage.txt"
+
+# Run unit tests only (skip live DNS tests).
+test-short:
+	go test -race -short ./src/...
+
+# Build all packages.
+build:
+	go build ./src/...
+
+# Remove generated files.
+clean:
+	rm -f coverage.txt

--- a/src/nawala/checker.go
+++ b/src/nawala/checker.go
@@ -76,10 +76,12 @@ func New(opts ...Option) *Checker {
 		c.cache = newMemoryCache(c.cacheTTL)
 	}
 
-	// Initialize shared DNS client to reuse connections/resources.
-	c.dnsClient = &dns.Client{
-		Timeout: c.timeout,
-		Net:     "udp",
+	// Initialize shared DNS client if not set by WithDNSClient option.
+	if c.dnsClient == nil {
+		c.dnsClient = &dns.Client{
+			Timeout: c.timeout,
+			Net:     "udp",
+		}
 	}
 
 	return c

--- a/src/nawala/domain.go
+++ b/src/nawala/domain.go
@@ -42,7 +42,9 @@ func IsValidDomain(domain string) bool {
 	return true
 }
 
-// isValidLabel checks if a standard label is valid according to RFC 1035.
+// isValidLabel checks if a standard label is valid according to [RFC 1035].
+//
+// [RFC 1035]: https://datatracker.ietf.org/doc/html/rfc1035
 func isValidLabel(label string) bool {
 	// Labels must be 1-63 characters (RFC 1035)
 	if len(label) == 0 || len(label) > 63 {


### PR DESCRIPTION
- [+] Add WithDNSClient option supporting TCP, DoT, custom dialers
- [+] Update Checker init to use custom client if provided (ignore default)
- [+] Add comprehensive WithDNSClient tests (custom/nil/timeout/TCP)
- [+] Introduce Makefile with race-aware test/build/clean and coverage targets
- [+] Update .gitignore for coverage files
- [+] Add RFC 1035 documentation link in domain validation