### PR TITLE
fix(nawala): clamp negative maxRetries to default value

### DIFF
--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -617,3 +617,9 @@ func TestWithDNSClient(t *testing.T) {
 		assert.False(t, result.Blocked)
 	})
 }
+func TestWithNegativeMaxRetries(t *testing.T) {
+	c := New(WithMaxRetries(-5))
+
+	// Verify it exactly matches the default configuration
+	assert.Equal(t, defaultRetries, c.maxRetries, "maxRetries should default to defaultRetries when negative")
+}

--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -617,6 +617,7 @@ func TestWithDNSClient(t *testing.T) {
 		assert.False(t, result.Blocked)
 	})
 }
+
 func TestWithNegativeMaxRetries(t *testing.T) {
 	c := New(WithMaxRetries(-5))
 

--- a/src/nawala/option.go
+++ b/src/nawala/option.go
@@ -51,6 +51,9 @@ func WithTimeout(d time.Duration) Option {
 // The default is 2 retries (3 total attempts).
 func WithMaxRetries(n int) Option {
 	return func(c *Checker) {
+		if n < 0 {
+			n = defaultRetries // Use default on negative input
+		}
 		c.maxRetries = n
 	}
 }


### PR DESCRIPTION
- [+] Update WithMaxRetries option to default on negative input
- [+] Add TestWithNegativeMaxRetries to verify default handling