### PR TITLE
feat(nawala): add configurable EDNS0 size support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ c := nawala.New(
         Timeout: 10 * time.Second,
         Net:     "tcp-tls",
     }),
+
+    // Set custom EDNS0 size (default is 1232 to prevent fragmentation).
+    nawala.WithEDNS0Size(4096),
 )
 ```
 
@@ -117,6 +120,7 @@ c := nawala.New(
 | `WithCacheTTL(d)` | `5m` | TTL for the built-in in-memory cache |
 | `WithCache(c)` | in-memory | Custom `Cache` implementation (pass `nil` to disable) |
 | `WithConcurrency(n)` | `100` | Max concurrent DNS checks (semaphore size) |
+| `WithEDNS0Size(n)` | `1232` | EDNS0 UDP buffer size (prevents fragmentation) |
 | `WithDNSClient(c)` | UDP client | Custom `*dns.Client` for TCP, TLS, or custom dialer |
 | `WithServer(s)` | — | Add or replace a single DNS server |
 | `WithServers(s)` | Nawala defaults | Replace all DNS servers |

--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -460,6 +460,26 @@ func TestWithConcurrency(t *testing.T) {
 	}
 }
 
+func TestWithEDNS0Size(t *testing.T) {
+	// Test default EDNS0 size
+	c := New()
+	if c.edns0Size != defaultEDNS0Size {
+		t.Errorf("expected default EDNS0 size %d, got %d", defaultEDNS0Size, c.edns0Size)
+	}
+
+	// Test custom EDNS0 size
+	c = New(WithEDNS0Size(4096))
+	if c.edns0Size != 4096 {
+		t.Errorf("expected EDNS0 size 4096, got %d", c.edns0Size)
+	}
+
+	// Test invalid EDNS0 size (should be ignored and remain default)
+	c = New(WithEDNS0Size(0))
+	if c.edns0Size != defaultEDNS0Size {
+		t.Errorf("expected EDNS0 size %d, got %d", defaultEDNS0Size, c.edns0Size)
+	}
+}
+
 func TestCheckRaceCondition(t *testing.T) {
 	// Start a slow DNS server to ensure goroutines are still running
 	// when we cancel the context.

--- a/src/nawala/dns.go
+++ b/src/nawala/dns.go
@@ -49,11 +49,11 @@ func parseQueryType(qtype string) uint16 {
 //
 // [RFC 6891]: https://datatracker.ietf.org/doc/html/rfc6891
 // [RFC 8914]: https://datatracker.ietf.org/doc/html/rfc8914
-func queryDNS(ctx context.Context, client *dns.Client, domain, server string, qtype uint16) (*dns.Msg, error) {
+func queryDNS(ctx context.Context, client *dns.Client, domain, server string, qtype, edns0Size uint16) (*dns.Msg, error) {
 	msg := new(dns.Msg)
 	msg.SetQuestion(dns.Fqdn(domain), qtype)
 	msg.RecursionDesired = true
-	msg.SetEdns0(4096, false)
+	msg.SetEdns0(edns0Size, false)
 
 	// Ensure server has port.
 	if !strings.Contains(server, ":") {
@@ -102,10 +102,10 @@ func containsKeyword(msg *dns.Msg, keyword string) bool {
 
 // checkDNSHealth performs a health check on a single DNS server by
 // resolving "google.com" and measuring the latency.
-func checkDNSHealth(ctx context.Context, client *dns.Client, server string) ServerStatus {
+func checkDNSHealth(ctx context.Context, client *dns.Client, server string, edns0Size uint16) ServerStatus {
 	start := time.Now()
 
-	resp, err := queryDNS(ctx, client, "google.com", server, dns.TypeA)
+	resp, err := queryDNS(ctx, client, "google.com", server, dns.TypeA, edns0Size)
 	latency := time.Since(start).Milliseconds()
 
 	if err != nil {

--- a/src/nawala/dns_test.go
+++ b/src/nawala/dns_test.go
@@ -172,7 +172,7 @@ func TestQueryDNS(t *testing.T) {
 
 		ctx := context.Background()
 		client := &dns.Client{Timeout: 5 * time.Second, Net: "udp"}
-		msg, err := queryDNS(ctx, client, "example.com", addr, dns.TypeA)
+		msg, err := queryDNS(ctx, client, "example.com", addr, dns.TypeA, 1232)
 		require.NoError(t, err)
 		assert.NotEmpty(t, msg.Answer, "expected answer records")
 	})
@@ -189,7 +189,7 @@ func TestQueryDNS(t *testing.T) {
 		cancel()
 
 		client := &dns.Client{Timeout: 5 * time.Second, Net: "udp"}
-		_, err := queryDNS(ctx, client, "example.com", addr, dns.TypeA)
+		_, err := queryDNS(ctx, client, "example.com", addr, dns.TypeA, 1232)
 		assert.Error(t, err, "expected error for cancelled context")
 	})
 
@@ -205,7 +205,7 @@ func TestQueryDNS(t *testing.T) {
 
 		ctx := context.Background()
 		client := &dns.Client{Timeout: 5 * time.Second, Net: "udp"}
-		_, err := queryDNS(ctx, client, "example.com", addr, dns.TypeA)
+		_, err := queryDNS(ctx, client, "example.com", addr, dns.TypeA, 1232)
 		assert.NoError(t, err)
 	})
 
@@ -226,7 +226,7 @@ func TestQueryDNS(t *testing.T) {
 
 		client := &dns.Client{Timeout: 500 * time.Millisecond, Net: "udp"}
 		// This will fail because it'll try port 53, but that covers the code path.
-		_, err := queryDNS(ctx, client, "example.com", host, dns.TypeA)
+		_, err := queryDNS(ctx, client, "example.com", host, dns.TypeA, 1232)
 		if err == nil {
 			t.Log("query to port 53 unexpectedly succeeded (port 53 may be running)")
 		}
@@ -256,7 +256,7 @@ func TestCheckDNSHealth(t *testing.T) {
 
 		ctx := context.Background()
 		client := &dns.Client{Timeout: 5 * time.Second, Net: "udp"}
-		status := checkDNSHealth(ctx, client, addr)
+		status := checkDNSHealth(ctx, client, addr, 1232)
 		assert.True(t, status.Online, "expected Online=true")
 		assert.GreaterOrEqual(t, status.LatencyMs, int64(0))
 	})
@@ -266,7 +266,7 @@ func TestCheckDNSHealth(t *testing.T) {
 		defer cancel()
 
 		client := &dns.Client{Timeout: 500 * time.Millisecond, Net: "udp"}
-		status := checkDNSHealth(ctx, client, "127.0.0.1:19999")
+		status := checkDNSHealth(ctx, client, "127.0.0.1:19999", 1232)
 		assert.False(t, status.Online, "expected Online=false for unreachable server")
 		assert.Error(t, status.Error)
 	})
@@ -284,7 +284,7 @@ func TestCheckDNSHealth(t *testing.T) {
 
 		ctx := context.Background()
 		client := &dns.Client{Timeout: 5 * time.Second, Net: "udp"}
-		status := checkDNSHealth(ctx, client, addr)
+		status := checkDNSHealth(ctx, client, addr, 1232)
 		assert.False(t, status.Online, "expected Online=false for SERVFAIL")
 		assert.Error(t, status.Error)
 	})

--- a/src/nawala/option.go
+++ b/src/nawala/option.go
@@ -111,3 +111,16 @@ func WithDNSClient(client *dns.Client) Option {
 		}
 	}
 }
+
+// WithEDNS0Size sets the EDNS0 UDP buffer size.
+// The default is 1232 bytes, which is the recommended size to prevent
+// IP fragmentation over UDP.
+//
+// See: https://dnsflagday.net/2020/
+func WithEDNS0Size(size uint16) Option {
+	return func(c *Checker) {
+		if size > 0 {
+			c.edns0Size = size
+		}
+	}
+}


### PR DESCRIPTION
- [+] Add `WithEDNS0Size` option with default of 1232 bytes (prevents fragmentation)
- [+] Update `Checker` struct, `New`, `queryWithRetries`, and health checks to use EDNS0 size
- [+] Modify `queryDNS` and `checkDNSHealth` signatures to accept and apply EDNS0 size
- [+] Update all relevant tests to pass default EDNS0 size
- [+] Document new option in README table and example