### PR TITLE
docs: update README examples to demonstrate multiple DNS servers

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -94,11 +94,18 @@ c := nawala.New(
     nawala.WithCacheTTL(10 * time.Minute),
 
     // Ganti semua server DNS dengan server kustom.
-    nawala.WithServers([]nawala.DNSServer{{
-        Address:   "8.8.8.8",
-        Keyword:   "blocked",
-        QueryType: "A",
-    }}),
+    nawala.WithServers([]nawala.DNSServer{
+        {
+            Address:   "8.8.8.8",
+            Keyword:   "blocked",
+            QueryType: "A",
+        },
+        {
+            Address:   "8.8.4.4",
+            Keyword:   "blocked",
+            QueryType: "A",
+        },
+    }),
 
     // Batasi pemeriksaan serentak hingga 50 goroutine.
     nawala.WithConcurrency(50),
@@ -267,11 +274,18 @@ reddit.com.    30    IN    A    103.155.26.29
 Pemeriksa mendeteksi ini dengan memindai bagian Extra (yang berisi record OPT) untuk kata kunci `trustpositif` atau `komdigi`. Untuk menggunakan deteksi ini, konfigurasikan server dengan kata kunci yang sesuai:
 
 ```go
-nawala.WithServers([]nawala.DNSServer{{
-    Address:   "103.155.26.28",
-    Keyword:   "trustpositif",
-    QueryType: "A",
-}})
+nawala.WithServers([]nawala.DNSServer{
+    {
+        Address:   "103.155.26.28",
+        Keyword:   "trustpositif",
+        QueryType: "A",
+    },
+    {
+        Address:   "103.155.26.29",
+        Keyword:   "komdigi",
+        QueryType: "A",
+    },
+})
 ```
 
 ## Struktur Proyek

--- a/README.md
+++ b/README.md
@@ -95,11 +95,18 @@ c := nawala.New(
     nawala.WithCacheTTL(10 * time.Minute),
 
     // Replace all DNS servers with custom ones.
-    nawala.WithServers([]nawala.DNSServer{{
-        Address:   "8.8.8.8",
-        Keyword:   "blocked",
-        QueryType: "A",
-    }}),
+    nawala.WithServers([]nawala.DNSServer{
+        {
+            Address:   "8.8.8.8",
+            Keyword:   "blocked",
+            QueryType: "A",
+        },
+        {
+            Address:   "8.8.4.4",
+            Keyword:   "blocked",
+            QueryType: "A",
+        },
+    }),
 
     // Limit concurrent checks to 50 goroutines.
     nawala.WithConcurrency(50),
@@ -268,11 +275,18 @@ reddit.com.    30    IN    A    103.155.26.29
 The checker detects this by scanning the Extra section (which contains the OPT record) for the keyword `trustpositif` or `komdigi`. To use this detection, configure a server with the appropriate keyword:
 
 ```go
-nawala.WithServers([]nawala.DNSServer{{
-    Address:   "103.155.26.28",
-    Keyword:   "trustpositif",
-    QueryType: "A",
-}})
+nawala.WithServers([]nawala.DNSServer{
+    {
+        Address:   "103.155.26.28",
+        Keyword:   "trustpositif",
+        QueryType: "A",
+    },
+    {
+        Address:   "103.155.26.29",
+        Keyword:   "komdigi",
+        QueryType: "A",
+    },
+})
 ```
 
 ## Project Structure


### PR DESCRIPTION
- [+] Expand `WithServers` example to include 8.8.8.8 and 8.8.4.4 (blocked keyword) in README.md and README.id.md
- [+] Expand trustpositif/komdigi example to include both 103.155.26.28 and 103.155.26.29 servers in both README files