### PR TITLE
docs: clarify ServerStatus.LatencyMs details in README files

### DIFF
--- a/examples/README.id.md
+++ b/examples/README.id.md
@@ -191,7 +191,9 @@ for _, s := range statuses {
   `ServerStatus` per server
 - `ServerStatus.Online` bernilai `true` saat server merespons probe kesehatan
   dalam timeout yang dikonfigurasi
-- `ServerStatus.LatencyMs` adalah waktu pulang-pergi dalam milidetik
+- `ServerStatus.LatencyMs` adalah `int64` dari **milidetik bulat** (misalnya `12`
+  berarti 12 ms); hanya diisi saat `Online` bernilai `true` — server yang
+  offline meninggalkannya sebagai `0`
 - `ServerStatus.Error` bernilai non-nil saat probe kesehatan itu sendiri gagal
 - Berguna untuk pemantauan atau pemeriksaan awal sebelum menjalankan
   pemeriksaan domain secara massal

--- a/examples/README.md
+++ b/examples/README.md
@@ -189,6 +189,8 @@ for _, s := range statuses {
   per server
 - `ServerStatus.Online` is `true` when the server responds to a health
   probe within the configured timeout
-- `ServerStatus.LatencyMs` is the round-trip time in milliseconds
+- `ServerStatus.LatencyMs` is an `int64` of **whole milliseconds** (e.g., `12`
+  meaning 12 ms); it is only populated when `Online` is `true` — offline
+  servers leave it as `0`
 - `ServerStatus.Error` is non-nil when the health probe itself failed
 - Useful for monitoring or pre-flight checks before running bulk domain checks


### PR DESCRIPTION
- [+] Specify LatencyMs as int64 whole milliseconds (e.g., 12 ms), only populated when Online is true in English README
- [+] Add equivalent clarification for offline servers leaving it as 0 in English README
- [+] Apply same updates to Indonesian README.id.md