### PR TITLE
fix(nawala): disallow underscores in Punycode TLDs

### DIFF
--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -1231,6 +1231,9 @@ func TestCheckUnderscoreDomains(t *testing.T) {
 		{"underscore with digits", "app_v2_staging.cloud.example.io"},
 		// Mixed hyphens and underscores
 		{"hyphens and underscores", "my-app_v2.test-env_01.example.com"},
+		// Consecutive underscores
+		{"consecutive underscores", "__dmarc.example.com"},
+		{"trailing underscore in label", "test_.example.com"},
 	}
 
 	for _, tt := range tests {

--- a/src/nawala/domain.go
+++ b/src/nawala/domain.go
@@ -91,7 +91,13 @@ func isValidTLD(label string) bool {
 
 	// Check for Punycode TLD (starts with xn--)
 	if len(label) > 4 && strings.EqualFold(label[:4], "xn--") {
-		// Punycode TLDs follow standard hostname rules (already validated by isValidLabel).
+		// Punycode TLDs follow standard hostname rules (already validated by isValidLabel)
+		// but MUST NOT contain underscores, which are conditionally allowed in generic labels.
+		for _, c := range label {
+			if c == '_' {
+				return false
+			}
+		}
 		return true
 	}
 

--- a/src/nawala/domain_test.go
+++ b/src/nawala/domain_test.go
@@ -46,6 +46,7 @@ func TestIsValidDomain(t *testing.T) {
 		{"punycode prefix only case insensitive", "example.XN--", false},
 		{"trailing dot with space", "example.com. ", false},
 		{"double trailing dot", "example.com..", false},
+		{"punycode TLD with underscore", "example.xn--p1ai_", false},
 	}
 
 	for _, tt := range tests {
@@ -108,6 +109,7 @@ func TestIsValidTLD(t *testing.T) {
 
 		// Invalid: underscore in TLD
 		{"underscore in TLD", "c_m", false},
+		{"punycode TLD with underscore", "xn--p1ai_", false},
 
 		// Invalid: hyphen in TLD
 		{"hyphen in TLD", "co-m", false},


### PR DESCRIPTION
- [+] Add underscore prohibition check in isValidTLD for Punycode
- [+] Add test cases for consecutive and trailing underscores in labels
- [+] Update domain tests for Punycode TLDs containing underscores