### PR TITLE
feat(nawala): add NXDOMAIN handling to avoid unnecessary server failovers

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -61,7 +61,7 @@ func main() {
     ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
     defer cancel()
 
-    results, err := c.Check(ctx, "google.com", "reddit.com", "github.com")
+    results, err := c.Check(ctx, "google.com", "reddit.com", "github.com", "exam_ple.com")
     if err != nil {
         log.Fatal(err)
     }
@@ -199,6 +199,7 @@ var (
     ErrNoDNSServers  // Tidak ada server DNS yang dikonfigurasi
     ErrAllDNSFailed  // Semua server DNS gagal merespons
     ErrInvalidDomain // Nama domain gagal validasi
+    ErrNXDOMAIN      // Domain tidak ada (NXDOMAIN)
     ErrDNSTimeout    // Kueri DNS melebihi timeout yang dikonfigurasi
     ErrInternalPanic // Panic internal dipulihkan selama eksekusi
 )

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ func main() {
     ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
     defer cancel()
 
-    results, err := c.Check(ctx, "google.com", "reddit.com", "github.com")
+    results, err := c.Check(ctx, "google.com", "reddit.com", "github.com", "exam_ple.com")
     if err != nil {
         log.Fatal(err)
     }
@@ -199,6 +199,7 @@ var (
     ErrNoDNSServers  // No DNS servers configured
     ErrAllDNSFailed  // All DNS servers failed to respond
     ErrInvalidDomain // Domain name failed validation
+    ErrNXDOMAIN      // Domain does not exist (NXDOMAIN)
     ErrDNSTimeout    // DNS query exceeded the configured timeout
     ErrInternalPanic // An internal panic was recovered during execution
 )

--- a/examples/README.id.md
+++ b/examples/README.id.md
@@ -54,7 +54,7 @@ c := nawala.New()
 ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 defer cancel()
 
-results, err := c.Check(ctx, "google.com", "reddit.com", "github.com")
+results, err := c.Check(ctx, "google.com", "reddit.com", "github.com", "exam_ple.com")
 if err != nil {
     log.Fatalf("check failed: %v", err)
 }
@@ -76,6 +76,7 @@ for _, r := range results {
 ```
 === Nawala DNS Blocker Check ===
 
+  exam_ple.com         error: nawala: nxdomain: domain does not exist (NXDOMAIN) (server: 180.131.144.144)
   google.com           tidak diblokir (server: 180.131.144.144)
   reddit.com           DIBLOKIR (server: 180.131.144.144)
   github.com           tidak diblokir (server: 180.131.144.144)

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,7 +55,7 @@ c := nawala.New()
 ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 defer cancel()
 
-results, err := c.Check(ctx, "google.com", "reddit.com", "github.com")
+results, err := c.Check(ctx, "google.com", "reddit.com", "github.com", "exam_ple.com")
 if err != nil {
     log.Fatalf("check failed: %v", err)
 }
@@ -77,6 +77,7 @@ for _, r := range results {
 ```
 === Nawala DNS Blocker Check ===
 
+  exam_ple.com         error: nawala: nxdomain: domain does not exist (NXDOMAIN) (server: 180.131.144.144)
   google.com           not blocked (server: 180.131.144.144)
   reddit.com           BLOCKED (server: 180.131.144.144)
   github.com           not blocked (server: 180.131.144.144)

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -27,6 +27,7 @@ func main() {
 
 	// Check multiple domains concurrently.
 	domains := []string{
+		"exam_ple.com",
 		"google.com",
 		"reddit.com",
 		"github.com",

--- a/src/nawala/dns.go
+++ b/src/nawala/dns.go
@@ -93,6 +93,10 @@ func queryDNS(ctx context.Context, q dnsQuery) (*dns.Msg, error) {
 		return nil, err
 	}
 
+	if resp != nil && resp.Rcode == dns.RcodeNameError {
+		return nil, fmt.Errorf("%w: domain does not exist (NXDOMAIN)", ErrNXDOMAIN)
+	}
+
 	return resp, nil
 }
 

--- a/src/nawala/docs.go
+++ b/src/nawala/docs.go
@@ -156,6 +156,7 @@
 //	    ErrNoDNSServers  // No DNS servers configured
 //	    ErrAllDNSFailed  // All DNS servers failed to respond
 //	    ErrInvalidDomain // Domain name failed validation
+//	    ErrNXDOMAIN      // Domain does not exist (NXDOMAIN)
 //	    ErrDNSTimeout    // DNS query exceeded the configured timeout
 //	    ErrInternalPanic // An internal panic was recovered during execution
 //	)

--- a/src/nawala/errors.go
+++ b/src/nawala/errors.go
@@ -24,4 +24,7 @@ var (
 
 	// ErrInternalPanic is returned when an internal panic is recovered during execution.
 	ErrInternalPanic = errors.New("nawala: internal panic recovered")
+
+	// ErrNXDOMAIN is returned when the DNS server responds with NXDOMAIN (domain does not exist).
+	ErrNXDOMAIN = errors.New("nawala: nxdomain")
 )


### PR DESCRIPTION
- [+] Introduce ErrNXDOMAIN for DNS RcodeNameError responses
- [+] Update queryDNS to wrap NXDOMAIN responses in ErrNXDOMAIN
- [+] Modify checker to return immediately on NXDOMAIN without failover
- [+] Add TestCheckNXDOMAIN for validation
- [+] Update godoc comments and error lists
- [+] Update READMEs and examples to demonstrate NXDOMAIN with "exam_ple.com"