### PR TITLE
feat(nawala): add ErrQueryRejected for explicit DNS rejections

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -202,6 +202,7 @@ var (
     ErrDNSTimeout    // Kueri DNS melebihi timeout yang dikonfigurasi
     ErrInternalPanic // Panic internal dipulihkan selama eksekusi
     ErrNXDOMAIN      // Domain tidak ada (NXDOMAIN)
+    ErrQueryRejected // Kueri secara eksplisit ditolak oleh server (Format Error, Refused, Not Implemented)
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ var (
     ErrDNSTimeout    // DNS query exceeded the configured timeout
     ErrInternalPanic // An internal panic was recovered during execution
     ErrNXDOMAIN      // Domain does not exist (NXDOMAIN)
+    ErrQueryRejected // Query explicitly rejected by server (Format Error, Refused, Not Implemented)
 )
 ```
 

--- a/src/nawala/checker.go
+++ b/src/nawala/checker.go
@@ -278,7 +278,7 @@ func (c *Checker) checkSingle(ctx context.Context, domain string) Result {
 		// Attempt DNS query with retries.
 		result, err := c.queryWithRetries(ctx, domain, srv, qtype)
 		if err != nil {
-			// If the domain strictly does not exist (NXDOMAIN), return immediately.
+			// If the domain strictly does not exist (NXDOMAIN) or query rejected by server (QueryRejected), return immediately.
 			// This is a definitive answer from the DNS server, so we shouldn't failover over it.
 			if errors.Is(err, ErrNXDOMAIN) || errors.Is(err, ErrQueryRejected) {
 				return Result{

--- a/src/nawala/checker.go
+++ b/src/nawala/checker.go
@@ -280,7 +280,7 @@ func (c *Checker) checkSingle(ctx context.Context, domain string) Result {
 		if err != nil {
 			// If the domain strictly does not exist (NXDOMAIN), return immediately.
 			// This is a definitive answer from the DNS server, so we shouldn't failover over it.
-			if errors.Is(err, ErrNXDOMAIN) {
+			if errors.Is(err, ErrNXDOMAIN) || errors.Is(err, ErrQueryRejected) {
 				return Result{
 					Domain: domain,
 					Server: srv.Address,
@@ -345,11 +345,11 @@ func (c *Checker) queryWithRetries(ctx context.Context, domain string, srv DNSSe
 			edns0Size: c.edns0Size,
 		})
 		if err != nil {
-			// If the domain strictly does not exist, do not retry.
-			if errors.Is(err, ErrNXDOMAIN) {
+			// If the domain strictly does not exist, or the server explicitly rejected the query, do not retry.
+			if errors.Is(err, ErrNXDOMAIN) || errors.Is(err, ErrQueryRejected) {
 				return Result{}, err
 			}
-			
+
 			lastErr = err
 			continue
 		}

--- a/src/nawala/dns.go
+++ b/src/nawala/dns.go
@@ -98,6 +98,7 @@ func queryDNS(ctx context.Context, q dnsQuery) (*dns.Msg, error) {
 		switch resp.Rcode {
 		case dns.RcodeNameError:
 			return nil, fmt.Errorf("%w: domain does not exist (NXDOMAIN)", ErrNXDOMAIN)
+			// TODO: do we need to remove this? or just return the error?
 		case dns.RcodeFormatError, dns.RcodeNotImplemented, dns.RcodeRefused:
 			return nil, fmt.Errorf("%w: (rcode: %s)", ErrQueryRejected, dns.RcodeToString[resp.Rcode])
 		}

--- a/src/nawala/docs.go
+++ b/src/nawala/docs.go
@@ -54,7 +54,7 @@
 //     domain names
 //   - Typed errors — sentinel errors for [errors.Is] matching
 //     ([ErrNoDNSServers], [ErrAllDNSFailed], [ErrInvalidDomain],
-//     [ErrDNSTimeout], [ErrInternalPanic], [ErrNXDOMAIN])
+//     [ErrDNSTimeout], [ErrInternalPanic], [ErrNXDOMAIN], [ErrQueryRejected])
 //
 // # Quick Start
 //
@@ -159,6 +159,7 @@
 //	    ErrDNSTimeout    // DNS query exceeded the configured timeout
 //	    ErrInternalPanic // An internal panic was recovered during execution
 //	    ErrNXDOMAIN      // Domain does not exist (NXDOMAIN)
+//	    ErrQueryRejected // Query explicitly rejected by server (Format Error, Refused, Not Implemented)
 //	)
 //
 // # Custom Cache

--- a/src/nawala/errors.go
+++ b/src/nawala/errors.go
@@ -27,4 +27,8 @@ var (
 
 	// ErrNXDOMAIN is returned when the DNS server responds with NXDOMAIN (domain does not exist).
 	ErrNXDOMAIN = errors.New("nawala: nxdomain")
+
+	// ErrQueryRejected is returned when a DNS server explicitly rejects a query
+	// (e.g., Format Error, Refused, Not Implemented).
+	ErrQueryRejected = errors.New("nawala: query rejected by server")
 )


### PR DESCRIPTION
- [+] Introduce ErrQueryRejected sentinel for RcodeFormatError, Refused, NotImplemented
- [+] Treat ErrQueryRejected like ErrNXDOMAIN (fast-fail, no retries/failover)
- [+] Add TestCheckQueryRejected_NoFailover to verify no-failover behavior
- [+] Update README.md, README.id.md, and godoc comments with new error