### PR TITLE
docs: clarify cloud deployment and Indonesian IP requirements

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -17,7 +17,7 @@ SDK Go untuk memeriksa apakah domain diblokir oleh filter DNS ISP Indonesia (Naw
 > **SDK ini tidak usang atau ketinggalan zaman.** Meskipun ada rumor bahwa proyek Nawala yang asli mungkin berhenti beroperasi, modul ini tetap menjadi **perangkat pemeriksaan DNS tujuan umum** yang dibangun dari dasar dengan konfigurasi server dan klien DNS yang dapat disesuaikan. Anda dapat mengarahkannya ke server DNS mana pun, menentukan kata kunci pemblokiran Anda sendiri, dan memasang instance `*dns.Client` kustom (TCP, DNS-over-TLS, dialer kustom, dll.). Server Nawala default hanyalah default yang sudah dikonfigurasi sebelumnya; SDK itu sendiri sepenuhnya independen dan dipelihara secara aktif.
 
 > [!TIP]
-> Jika berjalan pada infrastruktur cloud (misalnya, VPS, microservice, k8s), lebih baik mengimplementasikan server DNS sendiri menggunakan jaringan Indonesia, kemudian dari infrastruktur cloud cukup memanggilnya.
+> Saat berjalan pada infrastruktur cloud (misalnya, VPS, microservice, [k8s](https://kubernetes.io)) yang tidak berada pada jaringan Indonesia (misalnya, server Singapura atau AS), implementasikan server DNS Anda sendiri di jaringan Indonesia, kemudian arahkan SDK ini ke sana menggunakan `WithServers`. Perilaku indikator pemblokiran bergantung pada server DNS yang digunakan; server Nawala/Komdigi default hanya mengembalikan indikator pemblokiran saat diquery dari IP sumber Indonesia.
 
 ## Fitur
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Go SDK for checking whether domains are blocked by Indonesian ISP DNS filters 
 > **This SDK is not deprecated or outdated.** Despite rumors that the original Nawala project may cease operations, this module remains a **general-purpose DNS checking toolkit** built from the ground up with customizable DNS server and client configurations. You can point it at any DNS server, define your own blocking keywords, and plug in custom `*dns.Client` instances (TCP, DNS-over-TLS, custom dialers, etc.). The default Nawala servers are simply pre-configured defaults; the SDK itself is fully independent and actively maintained.
 
 > [!TIP]
-> If running on cloud infrastructure (e.g., VPS, microservices, k8s), it's better to implement your own DNS server using an Indonesian network, then from the cloud infrastructure it just calls it.
+> When running on cloud infrastructure (e.g., VPS, microservices, [k8s](https://kubernetes.io)) that is not on an Indonesian network (e.g., a Singapore or US server), implement your own DNS server on an Indonesian network, then point this SDK at it using `WithServers`. Block indicator behavior depends on the DNS server in use; the default Nawala/Komdigi servers only return block indicators when queried from an Indonesian source IP.
 
 ## Features
 

--- a/examples/README.id.md
+++ b/examples/README.id.md
@@ -33,10 +33,12 @@ pemeriksa pemblokiran domain berbasis DNS untuk filter DNS ISP Indonesia
   lihat tips di bawah)
 
 > [!TIP]
-> Saat berjalan pada infrastruktur cloud (misalnya VPS, microservice, k8s),
-> deploy server DNS di dalam cluster Anda pada node jaringan Indonesia, lalu
-> arahkan checker ke sana menggunakan `WithServers`. Server Nawala/Komdigi
-> hanya akan merespons dengan indikator blokir saat melihat IP sumber Indonesia.
+> Saat berjalan pada infrastruktur cloud (misalnya, VPS, microservice, [k8s](https://kubernetes.io)) yang
+> tidak berada pada jaringan Indonesia (misalnya, server Singapura atau AS),
+> implementasikan server DNS Anda sendiri di jaringan Indonesia, kemudian arahkan
+> SDK ini ke sana menggunakan `WithServers`. Perilaku indikator pemblokiran bergantung
+> pada server DNS yang digunakan; server Nawala/Komdigi default hanya akan
+> mengembalikan indikator pemblokiran saat diquery dari IP sumber Indonesia.
 
 ## Menjalankan Contoh
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,11 +33,12 @@ DNS-based domain blocking checker for Indonesian ISP DNS filters
   Indonesian network — see the tip below)
 
 > [!TIP]
-> When running on cloud infrastructure (e.g., VPS, microservices, k8s),
-> deploy a DNS server inside your cluster on an Indonesian network node,
-> then point the checker at it using `WithServers`. The Nawala/Komdigi
-> servers will only respond with block indicators when they see an
-> Indonesian source IP.
+> When running on cloud infrastructure (e.g., VPS, microservices, [k8s](https://kubernetes.io)) that
+> is not on an Indonesian network (e.g., a Singapore or US server), implement
+> your own DNS server on an Indonesian network, then point this SDK at it
+> using `WithServers`. Block indicator behavior depends on the DNS server in
+> use; the default Nawala/Komdigi servers only return block indicators when
+> queried from an Indonesian source IP.
 
 ## Running an Example
 

--- a/src/nawala/docs.go
+++ b/src/nawala/docs.go
@@ -17,9 +17,12 @@
 // within Indonesia. Ensure your connection uses a pure Indonesian IP
 // with no routing through networks outside Indonesia.
 //
-// If running on cloud infrastructure (e.g., VPS, microservices, [k8s]),
-// it is better to implement your own DNS server using an Indonesian
-// network, then from the cloud infrastructure simply call it.
+// When running on cloud infrastructure (e.g., VPS, microservices, [k8s])
+// that is not on an Indonesian network (e.g., a Singapore or US server),
+// implement your own DNS server on an Indonesian network, then point this
+// SDK at it using [WithServers]. Block indicator behavior depends on the
+// DNS server in use; the default Nawala/Komdigi servers only return block
+// indicators when queried from an Indonesian source IP.
 //
 // # General-Purpose Design
 //


### PR DESCRIPTION
- [+] Update README.md and README.id.md TIP sections with links and precise guidance on non-Indonesian cloud setups using WithServers
- [+] Revise examples/README.md and examples/README.id.md for consistent cloud infrastructure advice and block indicator details
- [+] Enhance src/nawala/docs.go with refined explanation of Indonesian source IP dependency and WithServers usage