### PR TITLE
Update [CI/CD] 🧪 Test Coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,8 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
-      if: matrix.os == 'ubuntu-latest'
+      # Only upload coverage for the starter/minimum Go version (1.25.6)
+      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.6'
       # continue-on-error: true
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- [+] chore(ci): restrict Codecov upload to ubuntu-latest and Go 1.25.6