### PR TITLE
chore(workflow): ignore documentation files in test triggers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,10 @@ on:
       - '.gitignore'
       - '.ignore'
       - '**/Makefile'
+      - 'CODE_OF_CONDUCT.md'
+      - 'CODE_OF_CONDUCT.id.md'
+      - 'CONTRIBUTING.md'
+      - 'CONTRIBUTING.id.md'
   pull_request:
     branches: [ master ]
     paths-ignore:
@@ -24,6 +28,10 @@ on:
       - '.gitignore'
       - '.ignore'
       - '**/Makefile'
+      - 'CODE_OF_CONDUCT.md'
+      - 'CODE_OF_CONDUCT.id.md'
+      - 'CONTRIBUTING.md'
+      - 'CONTRIBUTING.id.md'
 
 jobs:
   coverage:


### PR DESCRIPTION
- [+] Add CODE_OF_CONDUCT.md, CODE_OF_CONDUCT.id.md, CONTRIBUTING.md, and CONTRIBUTING.id.md to paths-ignore for push and pull_request events