### PR TITLE
docs(contributing): add hyperlinks to referenced files

### DIFF
--- a/CONTRIBUTING.id.md
+++ b/CONTRIBUTING.id.md
@@ -53,7 +53,7 @@ git checkout -b feature/nama-fitur-anda
 ### 2. Melakukan Perubahan
 
 **Standar Kode**:
-*   Pastikan semua opsi konfigurasi baru menggunakan pola **Functional Options** di `src/nawala/option.go`.
+*   Pastikan semua opsi konfigurasi baru menggunakan pola **Functional Options** di [`src/nawala/option.go`](src/nawala/option.go).
 *   Semua metode yang melakukan I/O (Input/Output) harus menerima `context.Context` sebagai argumen pertama.
 *   Hindari menambahkan dependensi pihak ketiga kecuali benar-benar diperlukan.
 
@@ -65,8 +65,8 @@ git checkout -b feature/nama-fitur-anda
     ```
 
 **Dokumentasi (Sinkronisasi Multibahasa & Kode)**:
-*   `nawala-checker` mengelola dokumentasi dalam bahasa Inggris (`README.md`) dan bahasa Indonesia (`README.id.md`), serta dokumentasi level-paket (GoDoc) di `src/nawala/docs.go`.
-*   Jika Pull Request Anda menambahkan fitur baru, mengubah API publik, atau memodifikasi perilaku yang ada, Anda **wajib memperbarui `README.md`, `README.id.md`, `src/nawala/docs.go`, serta kode terkait di direktori `examples/`** untuk memastikan keakuratan teknis dan konsistensi di seluruh sumber dokumentasi.
+*   `nawala-checker` mengelola dokumentasi dalam bahasa Inggris ([`README.md`](README.md)) dan bahasa Indonesia ([`README.id.md`](README.id.md)), serta dokumentasi level-paket (GoDoc) di [`src/nawala/docs.go`](src/nawala/docs.go).
+*   Jika Pull Request Anda menambahkan fitur baru, mengubah API publik, atau memodifikasi perilaku yang ada, Anda **wajib memperbarui [`README.md`](README.md), [`README.id.md`](README.id.md), [`src/nawala/docs.go`](src/nawala/docs.go), serta kode terkait di direktori [`examples/`](examples/)** untuk memastikan keakuratan teknis dan konsistensi di seluruh sumber dokumentasi.
 
 ### 3. Melakukan Commit dan Pemformatan
 Sebelum melakukan komit, pastikan kode Anda diformat dengan benar:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ git checkout -b feature/your-feature-name
 ### 2. Making Changes
 
 **Code Standards**:
-*   Ensure all new configuration options use the **Functional Options** pattern in `src/nawala/option.go`.
+*   Ensure all new configuration options use the **Functional Options** pattern in [`src/nawala/option.go`](src/nawala/option.go).
 *   All methods performing I/O must accept `context.Context` as the first argument.
 *   Avoid adding third-party dependencies unless absolutely necessary.
 
@@ -65,8 +65,8 @@ git checkout -b feature/your-feature-name
     ```
 
 **Documentation (Multilingual & Code Sync)**:
-*   The `nawala-checker` maintains both English (`README.md`) and Indonesian (`README.id.md`) documentation, as well as package-level GoDoc in `src/nawala/docs.go`.
-*   If your pull request adds a new feature, changes the public API, or modifies existing behavior, you **must update `README.md`, `README.id.md`, `src/nawala/docs.go`, and relevant code in the `examples/` directory** to ensure technical accuracy and consistency across all documentation sources.
+*   The `nawala-checker` maintains both English ([`README.md`](README.md)) and Indonesian ([`README.id.md`](README.id.md)) documentation, as well as package-level GoDoc in [`src/nawala/docs.go`](src/nawala/docs.go).
+*   If your pull request adds a new feature, changes the public API, or modifies existing behavior, you **must update [`README.md`](README.md), [`README.id.md`](README.id.md), [`src/nawala/docs.go`](src/nawala/docs.go), and relevant code in the [`examples/`](examples/) directory** to ensure technical accuracy and consistency across all documentation sources.
 
 ### 3. Committing and Formatting
 Before committing, ensure your code is properly formatted:


### PR DESCRIPTION
- [+] Update CONTRIBUTING.md with markdown links to src/nawala/option.go, READMEs, docs.go, and examples/
- [+] Update CONTRIBUTING.id.md with equivalent markdown links