### PR TITLE
refactor(config): extract option parsers into modular functions

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -63,47 +63,90 @@ func loadConfig(path string) (*Config, error) {
 // toOptions converts a Config into nawala SDK functional options.
 // Zero-value fields are ignored, allowing the SDK defaults to apply.
 func (c *Config) toOptions() ([]nawala.Option, error) {
+	parsers := []func() (nawala.Option, error){
+		c.parseTimeout,
+		c.parseMaxRetries,
+		c.parseCacheTTL,
+		c.parseConcurrency,
+		c.parseEDNS0Size,
+		c.parseServers,
+	}
+
 	var opts []nawala.Option
-
-	if c.Timeout != "" {
-		d, err := time.ParseDuration(c.Timeout)
+	for _, parse := range parsers {
+		opt, err := parse()
 		if err != nil {
-			return nil, fmt.Errorf("invalid timeout %q: %w", c.Timeout, err)
+			return nil, err
 		}
-		opts = append(opts, nawala.WithTimeout(d))
-	}
-
-	if c.MaxRetries != nil {
-		opts = append(opts, nawala.WithMaxRetries(*c.MaxRetries))
-	}
-
-	if c.CacheTTL != "" {
-		d, err := time.ParseDuration(c.CacheTTL)
-		if err != nil {
-			return nil, fmt.Errorf("invalid cache_ttl %q: %w", c.CacheTTL, err)
+		// Only append if the field was defined (not nil)
+		if opt != nil {
+			opts = append(opts, opt)
 		}
-		opts = append(opts, nawala.WithCacheTTL(d))
-	}
-
-	if c.Concurrency != nil {
-		opts = append(opts, nawala.WithConcurrency(*c.Concurrency))
-	}
-
-	if c.EDNS0Size != nil {
-		opts = append(opts, nawala.WithEDNS0Size(*c.EDNS0Size))
-	}
-
-	if c.Servers != nil {
-		servers := make([]nawala.DNSServer, len(c.Servers))
-		for i, s := range c.Servers {
-			servers[i] = nawala.DNSServer{
-				Address:   s.Address,
-				Keyword:   s.Keyword,
-				QueryType: s.QueryType,
-			}
-		}
-		opts = append(opts, nawala.WithServers(servers))
 	}
 
 	return opts, nil
+}
+
+// parseTimeout parses the timeout string into a time.Duration and returns a WithTimeout option.
+func (c *Config) parseTimeout() (nawala.Option, error) {
+	if c.Timeout == "" {
+		return nil, nil
+	}
+	d, err := time.ParseDuration(c.Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("invalid timeout %q: %w", c.Timeout, err)
+	}
+	return nawala.WithTimeout(d), nil
+}
+
+// parseMaxRetries returns a WithMaxRetries option if the MaxRetries field is defined.
+func (c *Config) parseMaxRetries() (nawala.Option, error) {
+	if c.MaxRetries == nil {
+		return nil, nil
+	}
+	return nawala.WithMaxRetries(*c.MaxRetries), nil
+}
+
+// parseCacheTTL parses the cache_ttl string into a time.Duration and returns a WithCacheTTL option.
+func (c *Config) parseCacheTTL() (nawala.Option, error) {
+	if c.CacheTTL == "" {
+		return nil, nil
+	}
+	d, err := time.ParseDuration(c.CacheTTL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cache_ttl %q: %w", c.CacheTTL, err)
+	}
+	return nawala.WithCacheTTL(d), nil
+}
+
+// parseConcurrency returns a WithConcurrency option if the Concurrency field is defined.
+func (c *Config) parseConcurrency() (nawala.Option, error) {
+	if c.Concurrency == nil {
+		return nil, nil
+	}
+	return nawala.WithConcurrency(*c.Concurrency), nil
+}
+
+// parseEDNS0Size returns a WithEDNS0Size option if the EDNS0Size field is defined.
+func (c *Config) parseEDNS0Size() (nawala.Option, error) {
+	if c.EDNS0Size == nil {
+		return nil, nil
+	}
+	return nawala.WithEDNS0Size(*c.EDNS0Size), nil
+}
+
+// parseServers converts the config ServerDefs into nawala.DNSServer structs and returns a WithServers option.
+func (c *Config) parseServers() (nawala.Option, error) {
+	if c.Servers == nil {
+		return nil, nil
+	}
+	servers := make([]nawala.DNSServer, len(c.Servers))
+	for i, s := range c.Servers {
+		servers[i] = nawala.DNSServer{
+			Address:   s.Address,
+			Keyword:   s.Keyword,
+			QueryType: s.QueryType,
+		}
+	}
+	return nawala.WithServers(servers), nil
 }


### PR DESCRIPTION
- [+] Replace inline field checks in toOptions with slice of parser functions
- [+] Add parseTimeout to handle timeout duration parsing
- [+] Add parseMaxRetries to handle optional retries
- [+] Add parseCacheTTL to handle cache TTL duration parsing
- [+] Add parseConcurrency to handle optional concurrency
- [+] Add parseEDNS0Size to handle optional EDNS0 size
- [+] Add parseServers to convert ServerDefs to DNSServer slices