### PR TITLE
refactor(cli): switch JSON output from NDJSON to wrapped arrays

### DIFF
--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -17,9 +17,10 @@ import (
 
 // Writer handles formatted output of check results to stdout or a file.
 type Writer struct {
-	w      *bufio.Writer
-	closer io.Closer // non-nil when writing to a file
-	json   bool      // output as NDJSON
+	w           *bufio.Writer
+	closer      io.Closer // non-nil when writing to a file
+	json        bool      // output as JSON
+	jsonStarted bool      // tracks if we started the JSON array
 }
 
 // NewWriter creates a Writer that writes to the given path.
@@ -75,7 +76,7 @@ func (w *Writer) writeText(r nawala.Result) {
 	w.w.Flush()
 }
 
-// writeJSON writes a check result as a single NDJSON line.
+// writeJSON writes a check result as a JSON array element.
 func (w *Writer) writeJSON(r nawala.Result) {
 	jr := jsonResult{
 		Domain:  r.Domain,
@@ -85,9 +86,15 @@ func (w *Writer) writeJSON(r nawala.Result) {
 	if r.Error != nil {
 		jr.Error = r.Error.Error()
 	}
+
 	data, _ := json.Marshal(jr)
+	if !w.jsonStarted {
+		w.w.WriteString(`{"nawala":{"result":[`)
+		w.jsonStarted = true
+	} else {
+		w.w.WriteString(",")
+	}
 	w.w.Write(data)
-	w.w.WriteByte('\n')
 	w.w.Flush()
 }
 
@@ -130,7 +137,7 @@ func (w *Writer) writeStatusText(s nawala.ServerStatus) {
 	w.w.Flush()
 }
 
-// writeStatusJSON writes a server health status as a single NDJSON line.
+// writeStatusJSON writes a server health status as a JSON array element.
 func (w *Writer) writeStatusJSON(s nawala.ServerStatus) {
 	js := jsonStatus{
 		Server:    s.Server,
@@ -141,13 +148,23 @@ func (w *Writer) writeStatusJSON(s nawala.ServerStatus) {
 		js.Error = s.Error.Error()
 	}
 	data, _ := json.Marshal(js)
+
+	if !w.jsonStarted {
+		w.w.WriteString(`{"nawala":{"status":[`)
+		w.jsonStarted = true
+	} else {
+		w.w.WriteString(",")
+	}
 	w.w.Write(data)
-	w.w.WriteByte('\n')
 	w.w.Flush()
 }
 
-// Close flushes any buffered data and closes the underlying file (if any).
+// Close flushes any buffered data, writes JSON caps, and closes the file.
 func (w *Writer) Close() error {
+	if w.json && w.jsonStarted {
+		w.w.WriteString("]}}\n")
+		w.jsonStarted = false
+	}
 	if err := w.w.Flush(); err != nil {
 		return err
 	}

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -25,9 +25,9 @@ func testWriter(jsonMode bool) (*Writer, *bytes.Buffer) {
 	return &Writer{w: bufio.NewWriter(&buf), json: jsonMode}, &buf
 }
 
-// flushAndRead flushes the Writer and returns the buffer contents.
+// flushAndRead flushes the Writer, closes it (triggering array caps), and returns the buffer contents.
 func flushAndRead(w *Writer, buf *bytes.Buffer) string {
-	w.w.Flush()
+	w.Close()
 	return buf.String()
 }
 
@@ -104,8 +104,14 @@ func TestWriter_WriteResult_JSON(t *testing.T) {
 	})
 
 	out := flushAndRead(w, buf)
-	var jr jsonResult
-	require.NoError(t, json.Unmarshal([]byte(out), &jr))
+	var wrapper struct {
+		Nawala struct {
+			Result []jsonResult `json:"result"`
+		} `json:"nawala"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &wrapper))
+	require.Len(t, wrapper.Nawala.Result, 1)
+	jr := wrapper.Nawala.Result[0]
 
 	assert.Equal(t, "google.com", jr.Domain)
 	assert.False(t, jr.Blocked)
@@ -122,8 +128,14 @@ func TestWriter_WriteResult_JSONWithError(t *testing.T) {
 	})
 
 	out := flushAndRead(w, buf)
-	var jr jsonResult
-	require.NoError(t, json.Unmarshal([]byte(out), &jr))
+	var wrapper struct {
+		Nawala struct {
+			Result []jsonResult `json:"result"`
+		} `json:"nawala"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &wrapper))
+	require.Len(t, wrapper.Nawala.Result, 1)
+	jr := wrapper.Nawala.Result[0]
 
 	assert.Equal(t, "dns timeout", jr.Error)
 }
@@ -179,8 +191,14 @@ func TestWriter_WriteStatus_JSON_Online(t *testing.T) {
 	})
 
 	out := flushAndRead(w, buf)
-	var js jsonStatus
-	require.NoError(t, json.Unmarshal([]byte(out), &js))
+	var wrapper struct {
+		Nawala struct {
+			Status []jsonStatus `json:"status"`
+		} `json:"nawala"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &wrapper))
+	require.Len(t, wrapper.Nawala.Status, 1)
+	js := wrapper.Nawala.Status[0]
 
 	assert.Equal(t, "8.8.8.8", js.Server)
 	assert.True(t, js.Online)
@@ -197,8 +215,14 @@ func TestWriter_WriteStatus_JSON_Offline(t *testing.T) {
 	})
 
 	out := flushAndRead(w, buf)
-	var js jsonStatus
-	require.NoError(t, json.Unmarshal([]byte(out), &js))
+	var wrapper struct {
+		Nawala struct {
+			Status []jsonStatus `json:"status"`
+		} `json:"nawala"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &wrapper))
+	require.Len(t, wrapper.Nawala.Status, 1)
+	js := wrapper.Nawala.Status[0]
 
 	assert.Equal(t, "unreachable", js.Error)
 }


### PR DESCRIPTION
- [+] Add `jsonStarted` field to Writer struct for array tracking
- [+] Update `writeJSON`/`writeStatusJSON` to initiate `{"nawala":{"result":[` or `{"nawala":{"status":[` arrays with commas
- [+] Modify `Close` to append `]}}\n` for proper JSON closure when using JSON mode
- [+] Update tests to call `Close()` in `flushAndRead` and unmarshal wrapper structs with array assertions