### PR TITLE
feat(nawala): add explicit cache disabling support

### DIFF
--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -207,4 +207,3 @@ func TestBuildChecker_DisableCacheNoCache(t *testing.T) {
 	// FlushCache must not panic when cache is nil.
 	assert.NotPanics(t, func() { checker.FlushCache() })
 }
-

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -164,3 +164,47 @@ func TestConfig_ToOptions_InvalidCacheTTL(t *testing.T) {
 	_, err := cfg.toOptions()
 	assert.Error(t, err, "expected error for invalid cache_ttl")
 }
+
+// TestConfig_ToOptions_DisableCacheTrue verifies that disable_cache:true
+// emits a WithCache(nil) option, which is absent when disable_cache:false.
+func TestConfig_ToOptions_DisableCacheTrue(t *testing.T) {
+	disableTrue := true
+	disableFalse := false
+
+	cfgTrue := &Config{DisableCache: &disableTrue}
+	cfgFalse := &Config{DisableCache: &disableFalse}
+	cfgNil := &Config{}
+
+	optsTrue, err := cfgTrue.toOptions()
+	require.NoError(t, err)
+	assert.Len(t, optsTrue, 1, "disable_cache:true should produce exactly 1 option (WithCache(nil))")
+
+	optsFalse, err := cfgFalse.toOptions()
+	require.NoError(t, err)
+	assert.Len(t, optsFalse, 0, "disable_cache:false should produce no options")
+
+	optsNil, err := cfgNil.toOptions()
+	require.NoError(t, err)
+	assert.Len(t, optsNil, 0, "nil DisableCache should produce no options")
+}
+
+// TestBuildChecker_DisableCacheNoCache verifies the full CLI→SDK path:
+// a config file with disable_cache:true must produce a Checker whose
+// FlushCache() is a safe no-op (cache is nil, not re-created by New()).
+func TestBuildChecker_DisableCacheNoCache(t *testing.T) {
+	content := `{"disable_cache": true}`
+	path := filepath.Join(t.TempDir(), "nocache.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	saved := configPath
+	configPath = path
+	defer func() { configPath = saved }()
+
+	checker, err := buildChecker()
+	require.NoError(t, err)
+	require.NotNil(t, checker)
+
+	// FlushCache must not panic when cache is nil.
+	assert.NotPanics(t, func() { checker.FlushCache() })
+}
+

--- a/src/nawala/checker.go
+++ b/src/nawala/checker.go
@@ -47,6 +47,7 @@ type Checker struct {
 	maxRetries  int
 	concurrency int
 	cache       Cache
+	cacheSet    bool // true when WithCache was called explicitly (even with nil)
 	cacheTTL    time.Duration
 	edns0Size   uint16
 	dnsClient   *dns.Client
@@ -78,8 +79,9 @@ func New(opts ...Option) *Checker {
 		opt(c)
 	}
 
-	// Initialize cache if not set by option.
-	if c.cache == nil {
+	// Initialize cache only when WithCache was not explicitly called.
+	// If WithCache(nil) was called, cacheSet is true and cache stays nil (disabled).
+	if !c.cacheSet {
 		c.cache = newMemoryCache(c.cacheTTL)
 	}
 

--- a/src/nawala/option.go
+++ b/src/nawala/option.go
@@ -131,6 +131,7 @@ func WithMaxRetries(n int) Option {
 func WithCache(cache Cache) Option {
 	return func(c *Checker) {
 		c.cache = cache
+		c.cacheSet = true
 	}
 }
 


### PR DESCRIPTION
- [+] Add `cacheSet` flag to `Checker` to track explicit `WithCache` calls and skip default cache init
- [+] Update `WithCache` option to always set `cacheSet=true` (even for `nil`)
- [+] Add tests for `disable_cache:true` producing `WithCache(nil)`, nil cache, and no panic on `FlushCache()`