### PR TITLE
feat(cli): add config subcommand with nawala envelope format

### DIFF
--- a/internal/cli/check_test.go
+++ b/internal/cli/check_test.go
@@ -231,11 +231,7 @@ func TestRunCheck_PartialFailure(t *testing.T) {
 	// Use a config with a non-routable DNS server and tiny timeout
 	// to force result-level errors (ErrPartialFailure).
 	badServerCfg := filepath.Join(t.TempDir(), "bad_server.json")
-	cfgContent := `{
-		"timeout": "1ms",
-		"max_retries": 0,
-		"servers": [{"address": "192.0.2.1", "keyword": "test", "query_type": "A"}]
-	}`
+	cfgContent := `{"nawala":{"configuration":{"timeout":"1ms","max_retries":0,"servers":[{"address":"192.0.2.1","keyword":"test","query_type":"A"}]}}}`
 	if err := os.WriteFile(badServerCfg, []byte(cfgContent), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +253,7 @@ func TestRunCheck_NoServers(t *testing.T) {
 	// Config with empty servers array causes ErrNoDNSServers,
 	// triggering the "check failed" error wrapping path.
 	cfgPath := filepath.Join(t.TempDir(), "no_servers.json")
-	if err := os.WriteFile(cfgPath, []byte(`{"servers": []}`), 0644); err != nil {
+	if err := os.WriteFile(cfgPath, []byte(`{"nawala":{"configuration":{"servers":[]}}}`), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -305,11 +301,7 @@ func TestRunCheck_Success(t *testing.T) {
 	mockAddr, cleanup := createMockDNSServer(t)
 	defer cleanup()
 
-	cfgContent := fmt.Sprintf(`{
-		"timeout": "1s",
-		"max_retries": 0,
-		"servers": [{"address": "%s", "keyword": "test", "query_type": "A"}]
-	}`, mockAddr)
+	cfgContent := fmt.Sprintf(`{"nawala":{"configuration":{"timeout":"1s","max_retries":0,"servers":[{"address":"%s","keyword":"test","query_type":"A"}]}}}`, mockAddr)
 
 	cfgPath := filepath.Join(t.TempDir(), "success.json")
 	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0644); err != nil {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -55,7 +55,7 @@ type ServerDef struct {
 // The file must use the nawala envelope format:
 //
 //	{"nawala":{"configuration":{...}}}  (JSON)
-//	
+//
 //	nawala:                              (YAML)
 //	  configuration:
 //	    timeout: 10s

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -28,6 +28,22 @@ type Config struct {
 	Servers      []ServerDef `json:"servers"       yaml:"servers"`
 }
 
+// configFile is the top-level envelope that wraps Config in a JSON or YAML
+// config file. The file format mirrors the JSON output envelope:
+//
+//	{"nawala":{"configuration":{...}}}
+//
+// Or in YAML:
+//
+//	nawala:
+//	  configuration:
+//	    timeout: 10s
+type configFile struct {
+	Nawala struct {
+		Configuration Config `json:"configuration" yaml:"configuration"`
+	} `json:"nawala" yaml:"nawala"`
+}
+
 // ServerDef defines a DNS server in the config file.
 type ServerDef struct {
 	Address   string `json:"address"    yaml:"address"`
@@ -36,28 +52,37 @@ type ServerDef struct {
 }
 
 // loadConfig reads and parses a JSON or YAML config file.
-// The format is detected by file extension (.json, .yaml, .yml).
+// The file must use the nawala envelope format:
+//
+//	{"nawala":{"configuration":{...}}}  (JSON)
+//	
+//	nawala:                              (YAML)
+//	  configuration:
+//	    timeout: 10s
+//
+// The format is auto-detected by file extension (.json, .yaml, .yml).
 func loadConfig(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config: %w", err)
 	}
 
-	var cfg Config
+	var cf configFile
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
 	case ".json":
-		if err := json.Unmarshal(data, &cfg); err != nil {
+		if err := json.Unmarshal(data, &cf); err != nil {
 			return nil, fmt.Errorf("parsing JSON config: %w", err)
 		}
 	case ".yaml", ".yml":
-		if err := yaml.Unmarshal(data, &cfg); err != nil {
+		if err := yaml.Unmarshal(data, &cf); err != nil {
 			return nil, fmt.Errorf("parsing YAML config: %w", err)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported config format %q (use .json, .yaml, or .yml)", ext)
 	}
 
+	cfg := cf.Nawala.Configuration
 	return &cfg, nil
 }
 

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 H0llyW00dzZ All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/H0llyW00dzZ/nawala-checker/src/nawala"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// configCmd is the "config" subcommand.
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Print the effective configuration",
+	Long:  configLong,
+	Args:  cobra.NoArgs,
+	RunE:  runConfig,
+}
+
+func init() {
+	configCmd.Flags().StringP("output", "o", "", "write config to a file instead of stdout")
+	configCmd.Flags().Bool("json", false, "output as JSON")
+	configCmd.Flags().Bool("yaml", false, "output as YAML (default)")
+}
+
+// effectiveConfig is the JSON/YAML-serialisable view of the resolved
+// configuration. Values are expressed as strings (durations) or primitives
+// so the output is always a valid config file the user can reuse.
+type effectiveConfig struct {
+	Timeout      string        `json:"timeout"        yaml:"timeout"`
+	MaxRetries   int           `json:"max_retries"    yaml:"max_retries"`
+	CacheTTL     string        `json:"cache_ttl"      yaml:"cache_ttl"`
+	DisableCache bool          `json:"disable_cache"  yaml:"disable_cache"`
+	Concurrency  int           `json:"concurrency"    yaml:"concurrency"`
+	EDNS0Size    uint16        `json:"edns0_size"     yaml:"edns0_size"`
+	Servers      []ServerDef   `json:"servers"        yaml:"servers"`
+}
+
+// sdkDefaults returns an effectiveConfig populated with the SDK's built-in defaults.
+// These mirror the constants in src/nawala/checker.go.
+func sdkDefaults() effectiveConfig {
+	servers := nawala.New().Servers()
+	defs := make([]ServerDef, len(servers))
+	for i, s := range servers {
+		defs[i] = ServerDef{
+			Address:   s.Address,
+			Keyword:   s.Keyword,
+			QueryType: s.QueryType,
+		}
+	}
+	return effectiveConfig{
+		Timeout:      (5 * time.Second).String(),
+		MaxRetries:   2,
+		CacheTTL:     (5 * time.Minute).String(),
+		DisableCache: false,
+		Concurrency:  100,
+		EDNS0Size:    1232,
+		Servers:      defs,
+	}
+}
+
+// mergeConfig overlays the user-supplied Config on top of the SDK defaults.
+func mergeConfig(base effectiveConfig, cfg *Config) effectiveConfig {
+	if cfg.Timeout != "" {
+		base.Timeout = cfg.Timeout
+	}
+	if cfg.MaxRetries != nil {
+		base.MaxRetries = *cfg.MaxRetries
+	}
+	if cfg.CacheTTL != "" {
+		base.CacheTTL = cfg.CacheTTL
+	}
+	if cfg.DisableCache != nil {
+		base.DisableCache = *cfg.DisableCache
+	}
+	if cfg.Concurrency != nil {
+		base.Concurrency = *cfg.Concurrency
+	}
+	if cfg.EDNS0Size != nil {
+		base.EDNS0Size = *cfg.EDNS0Size
+	}
+	if cfg.Servers != nil {
+		base.Servers = cfg.Servers
+	}
+	return base
+}
+
+// runConfig resolves the effective configuration and writes it to stdout or a file.
+func runConfig(cmd *cobra.Command, _ []string) error {
+	outputPath, _ := cmd.Flags().GetString("output")
+	jsonMode, _  := cmd.Flags().GetBool("json")
+
+	// Resolve effective config: start from SDK defaults, merge loaded file.
+	eff := sdkDefaults()
+	if configPath != "" {
+		cfg, err := loadConfig(configPath)
+		if err != nil {
+			return err
+		}
+		eff = mergeConfig(eff, cfg)
+	}
+
+	// Build the envelope.
+	type envelope struct {
+		Nawala struct {
+			Configuration effectiveConfig `json:"configuration" yaml:"configuration"`
+		} `json:"nawala" yaml:"nawala"`
+	}
+	var env envelope
+	env.Nawala.Configuration = eff
+
+	// Serialise.
+	var output []byte
+	var err error
+	if jsonMode {
+		output, err = json.Marshal(env)
+		if err != nil {
+			return fmt.Errorf("marshalling config: %w", err)
+		}
+		output = append(output, '\n')
+	} else {
+		output, err = yaml.Marshal(env)
+		if err != nil {
+			return fmt.Errorf("marshalling config: %w", err)
+		}
+	}
+
+	// Write to file or stdout.
+	if outputPath == "" {
+		_, err = fmt.Fprint(cmd.OutOrStdout(), string(output))
+		return err
+	}
+
+	w, err := NewWriter(outputPath, false)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+	w.w.WriteString(string(output))
+	return nil
+}

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -34,28 +34,36 @@ func init() {
 // configuration. Values are expressed as strings (durations) or primitives
 // so the output is always a valid config file the user can reuse.
 type effectiveConfig struct {
-	Timeout      string        `json:"timeout"        yaml:"timeout"`
-	MaxRetries   int           `json:"max_retries"    yaml:"max_retries"`
-	CacheTTL     string        `json:"cache_ttl"      yaml:"cache_ttl"`
-	DisableCache bool          `json:"disable_cache"  yaml:"disable_cache"`
-	Concurrency  int           `json:"concurrency"    yaml:"concurrency"`
-	EDNS0Size    uint16        `json:"edns0_size"     yaml:"edns0_size"`
-	Servers      []ServerDef   `json:"servers"        yaml:"servers"`
+	Timeout      string      `json:"timeout"        yaml:"timeout"`
+	MaxRetries   int         `json:"max_retries"    yaml:"max_retries"`
+	CacheTTL     string      `json:"cache_ttl"      yaml:"cache_ttl"`
+	DisableCache bool        `json:"disable_cache"  yaml:"disable_cache"`
+	Concurrency  int         `json:"concurrency"    yaml:"concurrency"`
+	EDNS0Size    uint16      `json:"edns0_size"     yaml:"edns0_size"`
+	Servers      []ServerDef `json:"servers"        yaml:"servers"`
 }
 
-// sdkDefaults returns an effectiveConfig populated with the SDK's built-in defaults.
-// These mirror the constants in src/nawala/checker.go.
-func sdkDefaults() effectiveConfig {
-	servers := nawala.New().Servers()
+// coalesce returns *ptr if ptr is non-nil, otherwise def.
+// Used to apply optional Config fields over effectiveConfig defaults.
+func coalesce[T any](ptr *T, def T) T {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
+// resolveEffectiveConfig builds the final configuration by starting from the
+// SDK defaults and overlaying any explicitly set fields from cfg (nil = use default).
+// cfg may be nil when no config file is loaded.
+func resolveEffectiveConfig(cfg *Config) effectiveConfig {
+	c := nawala.New()
+	servers := c.Servers()
 	defs := make([]ServerDef, len(servers))
 	for i, s := range servers {
-		defs[i] = ServerDef{
-			Address:   s.Address,
-			Keyword:   s.Keyword,
-			QueryType: s.QueryType,
-		}
+		defs[i] = ServerDef{Address: s.Address, Keyword: s.Keyword, QueryType: s.QueryType}
 	}
-	return effectiveConfig{
+
+	eff := effectiveConfig{
 		Timeout:      (5 * time.Second).String(),
 		MaxRetries:   2,
 		CacheTTL:     (5 * time.Minute).String(),
@@ -64,48 +72,46 @@ func sdkDefaults() effectiveConfig {
 		EDNS0Size:    1232,
 		Servers:      defs,
 	}
-}
 
-// mergeConfig overlays the user-supplied Config on top of the SDK defaults.
-func mergeConfig(base effectiveConfig, cfg *Config) effectiveConfig {
-	if cfg.Timeout != "" {
-		base.Timeout = cfg.Timeout
+	if cfg == nil {
+		return eff
 	}
-	if cfg.MaxRetries != nil {
-		base.MaxRetries = *cfg.MaxRetries
+
+	// Pointer fields: coalesce dereferences the pointer or keeps the default.
+	eff.MaxRetries = coalesce(cfg.MaxRetries, eff.MaxRetries)
+	eff.DisableCache = coalesce(cfg.DisableCache, eff.DisableCache)
+	eff.Concurrency = coalesce(cfg.Concurrency, eff.Concurrency)
+	eff.EDNS0Size = coalesce(cfg.EDNS0Size, eff.EDNS0Size)
+
+	// String/slice fields: empty/nil means "not set".
+	if cfg.Timeout != "" {
+		eff.Timeout = cfg.Timeout
 	}
 	if cfg.CacheTTL != "" {
-		base.CacheTTL = cfg.CacheTTL
-	}
-	if cfg.DisableCache != nil {
-		base.DisableCache = *cfg.DisableCache
-	}
-	if cfg.Concurrency != nil {
-		base.Concurrency = *cfg.Concurrency
-	}
-	if cfg.EDNS0Size != nil {
-		base.EDNS0Size = *cfg.EDNS0Size
+		eff.CacheTTL = cfg.CacheTTL
 	}
 	if cfg.Servers != nil {
-		base.Servers = cfg.Servers
+		eff.Servers = cfg.Servers
 	}
-	return base
+
+	return eff
 }
 
 // runConfig resolves the effective configuration and writes it to stdout or a file.
 func runConfig(cmd *cobra.Command, _ []string) error {
 	outputPath, _ := cmd.Flags().GetString("output")
-	jsonMode, _  := cmd.Flags().GetBool("json")
+	jsonMode, _ := cmd.Flags().GetBool("json")
 
-	// Resolve effective config: start from SDK defaults, merge loaded file.
-	eff := sdkDefaults()
+	// Resolve effective config: SDK defaults overlaid with any loaded file.
+	var cfg *Config
 	if configPath != "" {
-		cfg, err := loadConfig(configPath)
+		loaded, err := loadConfig(configPath)
 		if err != nil {
 			return err
 		}
-		eff = mergeConfig(eff, cfg)
+		cfg = loaded
 	}
+	eff := resolveEffectiveConfig(cfg)
 
 	// Build the envelope.
 	type envelope struct {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -123,24 +123,19 @@ func runConfig(cmd *cobra.Command, _ []string) error {
 	env.Nawala.Configuration = eff
 
 	// Serialise.
+	// effectiveConfig only contains string/int/bool/uint16 and []ServerDef —
+	// neither json.Marshal nor yaml.Marshal can fail for these types.
 	var output []byte
-	var err error
 	if jsonMode {
-		output, err = json.Marshal(env)
-		if err != nil {
-			return fmt.Errorf("marshalling config: %w", err)
-		}
+		output, _ = json.Marshal(env)
 		output = append(output, '\n')
 	} else {
-		output, err = yaml.Marshal(env)
-		if err != nil {
-			return fmt.Errorf("marshalling config: %w", err)
-		}
+		output, _ = yaml.Marshal(env)
 	}
 
 	// Write to file or stdout.
 	if outputPath == "" {
-		_, err = fmt.Fprint(cmd.OutOrStdout(), string(output))
+		_, err := fmt.Fprint(cmd.OutOrStdout(), string(output))
 		return err
 	}
 

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -1,0 +1,330 @@
+// Copyright (c) 2026 H0llyW00dzZ All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// newConfigCmd creates a fresh config command for isolated testing.
+func newConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "config",
+		Args: cobra.NoArgs,
+		RunE: runConfig,
+	}
+	cmd.Flags().StringP("output", "o", "", "write config to a file instead of stdout")
+	cmd.Flags().Bool("json", false, "output as JSON")
+	cmd.Flags().Bool("yaml", false, "output as YAML (default)")
+	return cmd
+}
+
+func TestRunConfig_DefaultsJSON(t *testing.T) {
+	saved := configPath
+	configPath = ""
+	defer func() { configPath = saved }()
+
+	var buf bytes.Buffer
+	cmd := newConfigCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("runConfig --json error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, `"nawala"`) {
+		t.Errorf("JSON output missing nawala envelope: %q", out)
+	}
+	if !strings.Contains(out, `"configuration"`) {
+		t.Errorf("JSON output missing configuration key: %q", out)
+	}
+
+	// Must be valid JSON.
+	var wrapper struct {
+		Nawala struct {
+			Configuration effectiveConfig `json:"configuration"`
+		} `json:"nawala"`
+	}
+	if err := json.Unmarshal([]byte(out), &wrapper); err != nil {
+		t.Fatalf("JSON output is not valid JSON: %v\n%s", err, out)
+	}
+	cfg := wrapper.Nawala.Configuration
+	if cfg.Timeout == "" {
+		t.Error("expected non-empty timeout in defaults")
+	}
+	if cfg.Concurrency == 0 {
+		t.Error("expected non-zero concurrency in defaults")
+	}
+	if len(cfg.Servers) == 0 {
+		t.Error("expected default servers")
+	}
+}
+
+func TestRunConfig_DefaultsYAML(t *testing.T) {
+	saved := configPath
+	configPath = ""
+	defer func() { configPath = saved }()
+
+	var buf bytes.Buffer
+	cmd := newConfigCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{}) // no format flag → YAML default
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("runConfig (yaml default) error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "nawala:") {
+		t.Errorf("YAML output missing nawala key: %q", out)
+	}
+	if !strings.Contains(out, "configuration:") {
+		t.Errorf("YAML output missing configuration key: %q", out)
+	}
+
+	// Must be valid YAML that round-trips.
+	var wrapper struct {
+		Nawala struct {
+			Configuration effectiveConfig `yaml:"configuration"`
+		} `yaml:"nawala"`
+	}
+	if err := yaml.Unmarshal([]byte(out), &wrapper); err != nil {
+		t.Fatalf("YAML output is not valid YAML: %v\n%s", err, out)
+	}
+	if wrapper.Nawala.Configuration.Timeout == "" {
+		t.Error("expected non-empty timeout in YAML defaults")
+	}
+}
+
+func TestRunConfig_FromFileJSON(t *testing.T) {
+	content := `{"nawala":{"configuration":{"timeout":"30s","concurrency":25}}}`
+	path := filepath.Join(t.TempDir(), "custom.json")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	saved := configPath
+	configPath = path
+	defer func() { configPath = saved }()
+
+	var buf bytes.Buffer
+	cmd := newConfigCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("runConfig --json with file error: %v", err)
+	}
+
+	var wrapper struct {
+		Nawala struct {
+			Configuration effectiveConfig `json:"configuration"`
+		} `json:"nawala"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &wrapper); err != nil {
+		t.Fatalf("JSON output invalid: %v", err)
+	}
+	cfg := wrapper.Nawala.Configuration
+	if cfg.Timeout != "30s" {
+		t.Errorf("expected timeout=30s, got %q", cfg.Timeout)
+	}
+	if cfg.Concurrency != 25 {
+		t.Errorf("expected concurrency=25, got %d", cfg.Concurrency)
+	}
+}
+
+func TestRunConfig_FromFileYAML(t *testing.T) {
+	content := `
+nawala:
+  configuration:
+    timeout: 20s
+    concurrency: 10
+`
+	path := filepath.Join(t.TempDir(), "custom.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	saved := configPath
+	configPath = path
+	defer func() { configPath = saved }()
+
+	var buf bytes.Buffer
+	cmd := newConfigCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{}) // YAML output
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("runConfig yaml with file error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "timeout: 20s") {
+		t.Errorf("YAML output missing merged timeout: %q", buf.String())
+	}
+}
+
+func TestRunConfig_BadConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(path, []byte("{invalid}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	saved := configPath
+	configPath = path
+	defer func() { configPath = saved }()
+
+	cmd := newConfigCmd()
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for bad config, got nil")
+	}
+}
+
+func TestRunConfig_OutputFile(t *testing.T) {
+	saved := configPath
+	configPath = ""
+	defer func() { configPath = saved }()
+
+	outPath := filepath.Join(t.TempDir(), "out.json")
+	cmd := newConfigCmd()
+	cmd.SetArgs([]string{"--json", "--output", outPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("runConfig -o error: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("reading output file: %v", err)
+	}
+	if !strings.Contains(string(data), `"nawala"`) {
+		t.Errorf("file output missing nawala envelope: %q", string(data))
+	}
+}
+
+func TestRunConfig_OutputFile_BadPath(t *testing.T) {
+	saved := configPath
+	configPath = ""
+	defer func() { configPath = saved }()
+
+	cmd := newConfigCmd()
+	cmd.SetArgs([]string{"--json", "--output", "/nonexistent/dir/out.json"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for bad output path, got nil")
+	}
+}
+
+func TestConfigCmd_Help(t *testing.T) {
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"config", "--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "configuration") {
+		t.Errorf("config --help missing description: %q", out)
+	}
+}
+
+func TestRunConfig_MarshalErrorJSON(t *testing.T) {
+	// For coverage symmetry — json.Marshal on effectiveConfig can't fail
+	// with real data, so just verify the happy path produces valid output.
+	eff := sdkDefaults()
+	if eff.Timeout == "" {
+		t.Error("sdkDefaults returned empty timeout")
+	}
+	if eff.EDNS0Size == 0 {
+		t.Error("sdkDefaults returned zero EDNS0Size")
+	}
+}
+
+func TestRunConfig_MergeConfig_AllFields(t *testing.T) {
+	base := sdkDefaults()
+	retries := 5
+	concurrency := 75
+	edns := uint16(2048)
+	disableCache := true
+	cfg := &Config{
+		Timeout:      "15s",
+		MaxRetries:   &retries,
+		CacheTTL:     "20m",
+		DisableCache: &disableCache,
+		Concurrency:  &concurrency,
+		EDNS0Size:    &edns,
+		Servers: []ServerDef{
+			{Address: "1.1.1.1", Keyword: "test", QueryType: "A"},
+		},
+	}
+	merged := mergeConfig(base, cfg)
+
+	if merged.Timeout != "15s" {
+		t.Errorf("expected timeout=15s, got %q", merged.Timeout)
+	}
+	if merged.MaxRetries != 5 {
+		t.Errorf("expected max_retries=5, got %d", merged.MaxRetries)
+	}
+	if merged.CacheTTL != "20m" {
+		t.Errorf("expected cache_ttl=20m, got %q", merged.CacheTTL)
+	}
+	if !merged.DisableCache {
+		t.Error("expected disable_cache=true")
+	}
+	if merged.Concurrency != 75 {
+		t.Errorf("expected concurrency=75, got %d", merged.Concurrency)
+	}
+	if merged.EDNS0Size != 2048 {
+		t.Errorf("expected edns0_size=2048, got %d", merged.EDNS0Size)
+	}
+	if len(merged.Servers) != 1 || merged.Servers[0].Address != "1.1.1.1" {
+		t.Errorf("unexpected servers: %v", merged.Servers)
+	}
+}
+
+func TestRunConfig_MergeConfig_EmptyFields(t *testing.T) {
+	base := sdkDefaults()
+	origTimeout := base.Timeout
+	cfg := &Config{} // all nil/zero — nothing should change
+	merged := mergeConfig(base, cfg)
+
+	if merged.Timeout != origTimeout {
+		t.Errorf("empty config changed timeout: got %q", merged.Timeout)
+	}
+}
+
+func TestConfigLongNotEmpty(t *testing.T) {
+	if configLong == "" {
+		t.Error("configLong is empty — embed failed")
+	}
+}
+
+// Also extend TestMagicEmbed_VarsNotEmpty coverage via this file's test.
+func TestConfigCmd_IsRegistered(t *testing.T) {
+	found := false
+	for _, sub := range rootCmd.Commands() {
+		if sub.Use == "config" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("configCmd is not registered on rootCmd")
+	}
+}
+
+func init() {
+	// Ensure fmt and yaml imports are used.
+	_ = fmt.Sprintf
+}

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -240,19 +240,17 @@ func TestConfigCmd_Help(t *testing.T) {
 }
 
 func TestRunConfig_MarshalErrorJSON(t *testing.T) {
-	// For coverage symmetry — json.Marshal on effectiveConfig can't fail
-	// with real data, so just verify the happy path produces valid output.
-	eff := sdkDefaults()
+	// For coverage symmetry — resolveEffectiveConfig(nil) returns SDK defaults.
+	eff := resolveEffectiveConfig(nil)
 	if eff.Timeout == "" {
-		t.Error("sdkDefaults returned empty timeout")
+		t.Error("resolveEffectiveConfig returned empty timeout")
 	}
 	if eff.EDNS0Size == 0 {
-		t.Error("sdkDefaults returned zero EDNS0Size")
+		t.Error("resolveEffectiveConfig returned zero EDNS0Size")
 	}
 }
 
 func TestRunConfig_MergeConfig_AllFields(t *testing.T) {
-	base := sdkDefaults()
 	retries := 5
 	concurrency := 75
 	edns := uint16(2048)
@@ -268,7 +266,7 @@ func TestRunConfig_MergeConfig_AllFields(t *testing.T) {
 			{Address: "1.1.1.1", Keyword: "test", QueryType: "A"},
 		},
 	}
-	merged := mergeConfig(base, cfg)
+	merged := resolveEffectiveConfig(cfg)
 
 	if merged.Timeout != "15s" {
 		t.Errorf("expected timeout=15s, got %q", merged.Timeout)
@@ -294,11 +292,10 @@ func TestRunConfig_MergeConfig_AllFields(t *testing.T) {
 }
 
 func TestRunConfig_MergeConfig_EmptyFields(t *testing.T) {
-	base := sdkDefaults()
-	origTimeout := base.Timeout
-	cfg := &Config{} // all nil/zero — nothing should change
-	merged := mergeConfig(base, cfg)
-
+	eff := resolveEffectiveConfig(nil)
+	origTimeout := eff.Timeout
+	// resolveEffectiveConfig with empty Config keeps defaults.
+	merged := resolveEffectiveConfig(&Config{})
 	if merged.Timeout != origTimeout {
 		t.Errorf("empty config changed timeout: got %q", merged.Timeout)
 	}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -16,15 +16,19 @@ import (
 
 func TestLoadConfig_JSON(t *testing.T) {
 	content := `{
-		"timeout": "10s",
-		"max_retries": 3,
-		"cache_ttl": "5m",
-		"disable_cache": true,
-		"concurrency": 50,
-		"edns0_size": 4096,
-		"servers": [
-			{"address": "8.8.8.8", "keyword": "blocked", "query_type": "A"}
-		]
+		"nawala": {
+			"configuration": {
+				"timeout": "10s",
+				"max_retries": 3,
+				"cache_ttl": "5m",
+				"disable_cache": true,
+				"concurrency": 50,
+				"edns0_size": 4096,
+				"servers": [
+					{"address": "8.8.8.8", "keyword": "blocked", "query_type": "A"}
+				]
+			}
+		}
 	}`
 
 	path := filepath.Join(t.TempDir(), "config.json")
@@ -53,16 +57,18 @@ func TestLoadConfig_JSON(t *testing.T) {
 
 func TestLoadConfig_YAML(t *testing.T) {
 	content := `
-timeout: 15s
-max_retries: 5
-cache_ttl: 10m
-disable_cache: false
-concurrency: 200
-edns0_size: 2048
-servers:
-  - address: "1.1.1.1"
-    keyword: "cloudflare"
-    query_type: "AAAA"
+nawala:
+  configuration:
+    timeout: 15s
+    max_retries: 5
+    cache_ttl: 10m
+    disable_cache: false
+    concurrency: 200
+    edns0_size: 2048
+    servers:
+      - address: "1.1.1.1"
+        keyword: "cloudflare"
+        query_type: "AAAA"
 `
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
@@ -82,7 +88,7 @@ servers:
 }
 
 func TestLoadConfig_YML(t *testing.T) {
-	content := `timeout: 5s`
+	content := "nawala:\n  configuration:\n    timeout: 5s\n"
 	path := filepath.Join(t.TempDir(), "config.yml")
 	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
 

--- a/internal/cli/magic_embed.go
+++ b/internal/cli/magic_embed.go
@@ -18,3 +18,6 @@ var checkLong string
 
 //go:embed usage/status_long.txt
 var statusLong string
+
+//go:embed usage/config_long.txt
+var configLong string

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -21,8 +21,8 @@ var rootCmd = &cobra.Command{
 	Short: "Check domains against Indonesian ISP DNS filters",
 	Long:  rootLong,
 	// When bare args are provided (no subcommand), delegate to check.
-	Args:          cobra.ArbitraryArgs,
-	RunE:          runRoot,
+	Args: cobra.ArbitraryArgs,
+	RunE: runRoot,
 }
 
 // runRoot is the root command handler. It prints the version when

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -51,6 +51,7 @@ func init() {
 
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(configCmd)
 }
 
 // Execute runs the root command and returns any error.

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -31,7 +31,7 @@ func TestBuildChecker_NoConfig(t *testing.T) {
 }
 
 func TestBuildChecker_WithConfig(t *testing.T) {
-	content := `{"timeout": "10s"}`
+	content := `{"nawala":{"configuration":{"timeout":"10s"}}}`
 	path := filepath.Join(t.TempDir(), "config.json")
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)
@@ -67,7 +67,7 @@ func TestBuildChecker_InvalidConfig(t *testing.T) {
 }
 
 func TestBuildChecker_InvalidDuration(t *testing.T) {
-	content := `{"timeout": "not-a-duration"}`
+	content := `{"nawala":{"configuration":{"timeout":"not-a-duration"}}}`
 	path := filepath.Join(t.TempDir(), "bad_timeout.json")
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)
@@ -211,6 +211,9 @@ func TestMagicEmbed_VarsNotEmpty(t *testing.T) {
 	if statusLong == "" {
 		t.Error("statusLong is empty — embed failed")
 	}
+	if configLong == "" {
+		t.Error("configLong is empty — embed failed")
+	}
 }
 
 // newStatusCmd creates a fresh status command for isolated testing.
@@ -263,11 +266,7 @@ func TestRunStatus_DNSError(t *testing.T) {
 
 	// Config with unreachable server + tiny timeout to force DNS error.
 	badCfg := filepath.Join(t.TempDir(), "bad_server.json")
-	cfgContent := `{
-		"timeout": "1ms",
-		"max_retries": 0,
-		"servers": [{"address": "192.0.2.1", "keyword": "test", "query_type": "A"}]
-	}`
+	cfgContent := `{"nawala":{"configuration":{"timeout":"1ms","max_retries":0,"servers":[{"address":"192.0.2.1","keyword":"test","query_type":"A"}]}}}`
 	if err := os.WriteFile(badCfg, []byte(cfgContent), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +287,7 @@ func TestRunStatus_NoServers(t *testing.T) {
 	// Config with empty servers array causes ErrNoDNSServers,
 	// triggering the "dns status check failed" error wrapping.
 	cfgPath := filepath.Join(t.TempDir(), "no_servers.json")
-	if err := os.WriteFile(cfgPath, []byte(`{"servers": []}`), 0644); err != nil {
+	if err := os.WriteFile(cfgPath, []byte(`{"nawala":{"configuration":{"servers":[]}}}`), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -333,11 +332,7 @@ func TestRunRoot_Success_Delegation(t *testing.T) {
 	mockAddr, cleanup := createMockDNSServer(t)
 	defer cleanup()
 
-	cfgContent := fmt.Sprintf(`{
-		"timeout": "1s",
-		"max_retries": 0,
-		"servers": [{"address": "%s", "keyword": "test", "query_type": "A"}]
-	}`, mockAddr)
+	cfgContent := fmt.Sprintf(`{"nawala":{"configuration":{"timeout":"1s","max_retries":0,"servers":[{"address":"%s","keyword":"test","query_type":"A"}]}}}`, mockAddr)
 
 	cfgPath := filepath.Join(t.TempDir(), "success_root.json")
 	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0644); err != nil {

--- a/internal/cli/usage/config_long.txt
+++ b/internal/cli/usage/config_long.txt
@@ -1,0 +1,33 @@
+The config command prints the effective configuration to stdout or a file.
+
+When no --config flag is provided, SDK defaults are shown. When --config is
+provided, the file is loaded and its values override the defaults; the final
+resolved configuration is printed.
+
+Output formats:
+
+  --yaml (default)   YAML in the nawala envelope schema
+  --json             JSON in the nawala envelope schema
+
+The output is always a valid config file that can be passed back to --config:
+
+  nawala config -o myconfig.json --json
+  nawala check --config myconfig.json --file domains.txt
+
+Config file format (JSON):
+
+  {
+    "nawala": {
+      "configuration": {
+        "timeout": "10s",
+        "max_retries": 2,
+        "cache_ttl": "5m",
+        "disable_cache": false,
+        "concurrency": 100,
+        "edns0_size": 1232,
+        "servers": [
+          {"address": "180.131.144.144", "keyword": "internetpositif", "query_type": "A"}
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
- [+] Introduce `config` command to print effective config (SDK defaults + file overrides) in JSON/YAML
- [+] Standardize config files with `{"nawala":{"configuration":{...}}}` envelope (JSON/YAML)
- [+] Update `loadConfig` to parse envelope and extract inner Config
- [+] Add `config_cmd.go`, `config_cmd_test.go` (330+ lines), and `usage/config_long.txt`
- [+] Embed `configLong` help text and register `configCmd` on `rootCmd`
- [+] Update all config tests (`check_test.go`, `config_test.go`, `root_test.go`) for envelope format