### PR TITLE
feat: add TCP/DoT protocol support with TLS options and CLI config command

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -65,7 +65,14 @@ nawala check google.com --json
 nawala check --file domains.txt -o results.txt
 
 # Gunakan konfigurasi kustom (JSON atau YAML)
-nawala check --config config.yaml --file domains.txt
+nawala check --config config.json --file domains.txt
+
+# Periksa konfigurasi efektif (tampilkan semua default)
+nawala config
+nawala config --json
+
+# Buat file konfigurasi
+nawala config -o myconfig.json --json
 
 # Tampilkan kesehatan dan latensi server DNS
 nawala status
@@ -74,26 +81,40 @@ nawala status
 nawala --version
 ```
 
-Contoh file konfigurasi (`config.yaml`):
+Contoh file konfigurasi (`config.json`) — format nawala envelope:
 
-```yaml
-timeout: 10s
-max_retries: 3
-cache_ttl: 10m
-disable_cache: false
-concurrency: 50
-servers:
-  - address: "180.131.144.144"
-    keyword: "internetpositif"
-    query_type: "A"
-  - address: "103.155.26.28"
-    keyword: "trustpositif"
-    query_type: "A"
+```json
+{
+  "nawala": {
+    "configuration": {
+      "timeout": "10s",
+      "max_retries": 3,
+      "cache_ttl": "10m",
+      "disable_cache": false,
+      "concurrency": 50,
+      "protocol": "udp",
+      "tls_server_name": "",
+      "tls_skip_verify": false,
+      "servers": [
+        {"address": "180.131.144.144", "keyword": "internetpositif", "query_type": "A"},
+        {"address": "103.155.26.28",  "keyword": "trustpositif",    "query_type": "A"}
+      ]
+    }
+  }
+}
 ```
 
 > [!NOTE]
 > Atur `disable_cache: true` untuk menonaktifkan cache dalam memori bawaan sepenuhnya.
 > Jika diaktifkan, nilai `cache_ttl` tidak berpengaruh.
+>
+> Atur `protocol` ke `"udp"` (default), `"tcp"`, atau `"tcp-tls"` (DNS over TLS / DoT)
+> untuk memilih transport DNS. Timeout dan ukuran EDNS0 tetap berlaku di semua protokol.
+>
+> Untuk `tcp-tls`, dua field TLS opsional tersedia:
+> - `tls_server_name` — mengganti nama SNI TLS (berguna saat alamat server berupa IP)
+> - `tls_skip_verify` — menonaktifkan verifikasi sertifikat; hanya untuk sertifikat self-signed, jangan digunakan di production
+
 
 ## Mulai Cepat
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,14 @@ nawala check google.com --json
 nawala check --file domains.txt -o results.txt
 
 # Use a custom config (JSON or YAML)
-nawala check --config config.yaml --file domains.txt
+nawala check --config config.json --file domains.txt
+
+# Inspect effective configuration (show all defaults)
+nawala config
+nawala config --json
+
+# Generate a config file
+nawala config -o myconfig.json --json
 
 # Show DNS server health and latency
 nawala status
@@ -74,26 +81,43 @@ nawala status
 nawala --version
 ```
 
-Configuration file example (`config.yaml`):
+Configuration file example (`config.json`) — nawala envelope format:
 
-```yaml
-timeout: 10s
-max_retries: 3
-cache_ttl: 10m
-disable_cache: false
-concurrency: 50
-servers:
-  - address: "180.131.144.144"
-    keyword: "internetpositif"
-    query_type: "A"
-  - address: "103.155.26.28"
-    keyword: "trustpositif"
-    query_type: "A"
+```json
+{
+  "nawala": {
+    "configuration": {
+      "timeout": "10s",
+      "max_retries": 3,
+      "cache_ttl": "10m",
+      "disable_cache": false,
+      "concurrency": 50,
+      "protocol": "udp",
+      "tls_server_name": "",
+      "tls_skip_verify": false,
+      "servers": [
+        {"address": "180.131.144.144", "keyword": "internetpositif", "query_type": "A"},
+        {"address": "103.155.26.28",  "keyword": "trustpositif",    "query_type": "A"}
+      ]
+    }
+  }
+}
 ```
 
 > [!NOTE]
 > Set `disable_cache: true` to disable the built-in in-memory cache entirely.
 > When set, `cache_ttl` has no effect.
+>
+> Set `protocol` to `"udp"` (default), `"tcp"`, or `"tcp-tls"` (DNS over TLS / DoT)
+> to select the DNS transport. Timeout and EDNS0 size compose correctly with all protocols.
+>
+> For `tcp-tls`, two optional fields control TLS:
+> - `tls_server_name` — sets the SNI and expected cert hostname. Required when the server
+>   address is an IP but the cert is issued for a hostname. Use this with `tls_skip_verify: false`
+>   for full cert verification against a trusted CA.
+> - `tls_skip_verify` — disables cert verification. Only for self-signed certs where no valid
+>   server name can be verified. Never use in production.
+
 
 ## Quick Start
 

--- a/cmd/nawala/docs.go
+++ b/cmd/nawala/docs.go
@@ -51,6 +51,9 @@
 //	      "cache_ttl": "10m",
 //	      "disable_cache": false,
 //	      "concurrency": 50,
+//	      "protocol": "udp",
+//	      "tls_server_name": "",
+//	      "tls_skip_verify": false,
 //	      "servers": [
 //	        {"address": "180.131.144.144", "keyword": "internetpositif", "query_type": "A"}
 //	      ]
@@ -67,12 +70,20 @@
 //	    cache_ttl: 10m
 //	    disable_cache: false
 //	    concurrency: 50
+//	    protocol: udp
+//	    tls_server_name: ""
+//	    tls_skip_verify: false
 //	    servers:
 //	      - address: "180.131.144.144"
 //	        keyword: "internetpositif"
 //	        query_type: "A"
 //
 // Use "nawala config" to generate a template with all SDK defaults filled in.
+//
+// The protocol field selects the DNS transport: "udp" (default), "tcp",
+// or "tcp-tls" (DNS over TLS / DoT).
+// For tcp-tls, set tls_server_name to override the SNI (useful when the server
+// address is an IP), and tls_skip_verify: true only for self-signed certs.
 //
 // # Exit Codes
 //

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -19,13 +19,16 @@ import (
 
 // Config holds the CLI configuration loaded from a JSON or YAML file.
 type Config struct {
-	Timeout      string      `json:"timeout"       yaml:"timeout"`
-	MaxRetries   *int        `json:"max_retries"   yaml:"max_retries"`
-	CacheTTL     string      `json:"cache_ttl"     yaml:"cache_ttl"`
-	DisableCache *bool       `json:"disable_cache" yaml:"disable_cache"`
-	Concurrency  *int        `json:"concurrency"   yaml:"concurrency"`
-	EDNS0Size    *uint16     `json:"edns0_size"    yaml:"edns0_size"`
-	Servers      []ServerDef `json:"servers"       yaml:"servers"`
+	Timeout       string      `json:"timeout"        yaml:"timeout"`
+	MaxRetries    *int        `json:"max_retries"    yaml:"max_retries"`
+	CacheTTL      string      `json:"cache_ttl"      yaml:"cache_ttl"`
+	DisableCache  *bool       `json:"disable_cache"  yaml:"disable_cache"`
+	Concurrency   *int        `json:"concurrency"    yaml:"concurrency"`
+	EDNS0Size     *uint16     `json:"edns0_size"     yaml:"edns0_size"`
+	Protocol      string      `json:"protocol"       yaml:"protocol"`
+	TLSServerName string      `json:"tls_server_name" yaml:"tls_server_name"`
+	TLSSkipVerify *bool       `json:"tls_skip_verify" yaml:"tls_skip_verify"`
+	Servers       []ServerDef `json:"servers"        yaml:"servers"`
 }
 
 // configFile is the top-level envelope that wraps Config in a JSON or YAML
@@ -96,6 +99,9 @@ func (c *Config) toOptions() ([]nawala.Option, error) {
 		c.parseDisableCache,
 		c.parseConcurrency,
 		c.parseEDNS0Size,
+		c.parseProtocol,
+		c.parseTLSServerName,
+		c.parseTLSSkipVerify,
 		c.parseServers,
 	}
 
@@ -168,6 +174,33 @@ func (c *Config) parseEDNS0Size() (nawala.Option, error) {
 		return nil, nil
 	}
 	return nawala.WithEDNS0Size(*c.EDNS0Size), nil
+}
+
+// parseProtocol returns a WithProtocol option if the Protocol field is set.
+// Valid values are "udp", "tcp", and "tcp-tls"; others are ignored by the SDK.
+func (c *Config) parseProtocol() (nawala.Option, error) {
+	if c.Protocol == "" {
+		return nil, nil
+	}
+	return nawala.WithProtocol(c.Protocol), nil
+}
+
+// parseTLSServerName returns a WithTLSServerName option if TLSServerName is set.
+// Only effective when protocol is "tcp-tls".
+func (c *Config) parseTLSServerName() (nawala.Option, error) {
+	if c.TLSServerName == "" {
+		return nil, nil
+	}
+	return nawala.WithTLSServerName(c.TLSServerName), nil
+}
+
+// parseTLSSkipVerify returns a WithTLSSkipVerify option if TLSSkipVerify is true.
+// Only effective when protocol is "tcp-tls".
+func (c *Config) parseTLSSkipVerify() (nawala.Option, error) {
+	if c.TLSSkipVerify != nil && *c.TLSSkipVerify {
+		return nawala.WithTLSSkipVerify(), nil
+	}
+	return nil, nil
 }
 
 // parseServers converts the config ServerDefs into nawala.DNSServer structs and returns a WithServers option.

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -34,13 +34,16 @@ func init() {
 // configuration. Values are expressed as strings (durations) or primitives
 // so the output is always a valid config file the user can reuse.
 type effectiveConfig struct {
-	Timeout      string      `json:"timeout"        yaml:"timeout"`
-	MaxRetries   int         `json:"max_retries"    yaml:"max_retries"`
-	CacheTTL     string      `json:"cache_ttl"      yaml:"cache_ttl"`
-	DisableCache bool        `json:"disable_cache"  yaml:"disable_cache"`
-	Concurrency  int         `json:"concurrency"    yaml:"concurrency"`
-	EDNS0Size    uint16      `json:"edns0_size"     yaml:"edns0_size"`
-	Servers      []ServerDef `json:"servers"        yaml:"servers"`
+	Timeout       string      `json:"timeout"         yaml:"timeout"`
+	MaxRetries    int         `json:"max_retries"     yaml:"max_retries"`
+	CacheTTL      string      `json:"cache_ttl"       yaml:"cache_ttl"`
+	DisableCache  bool        `json:"disable_cache"   yaml:"disable_cache"`
+	Concurrency   int         `json:"concurrency"     yaml:"concurrency"`
+	EDNS0Size     uint16      `json:"edns0_size"      yaml:"edns0_size"`
+	Protocol      string      `json:"protocol"        yaml:"protocol"`
+	TLSServerName string      `json:"tls_server_name,omitempty" yaml:"tls_server_name,omitempty"`
+	TLSSkipVerify bool        `json:"tls_skip_verify" yaml:"tls_skip_verify"`
+	Servers       []ServerDef `json:"servers"         yaml:"servers"`
 }
 
 // coalesce returns *ptr if ptr is non-nil, otherwise def.
@@ -70,6 +73,7 @@ func resolveEffectiveConfig(cfg *Config) effectiveConfig {
 		DisableCache: false,
 		Concurrency:  100,
 		EDNS0Size:    1232,
+		Protocol:     "udp",
 		Servers:      defs,
 	}
 
@@ -82,6 +86,7 @@ func resolveEffectiveConfig(cfg *Config) effectiveConfig {
 	eff.DisableCache = coalesce(cfg.DisableCache, eff.DisableCache)
 	eff.Concurrency = coalesce(cfg.Concurrency, eff.Concurrency)
 	eff.EDNS0Size = coalesce(cfg.EDNS0Size, eff.EDNS0Size)
+	eff.TLSSkipVerify = coalesce(cfg.TLSSkipVerify, eff.TLSSkipVerify)
 
 	// String/slice fields: empty/nil means "not set".
 	if cfg.Timeout != "" {
@@ -89,6 +94,12 @@ func resolveEffectiveConfig(cfg *Config) effectiveConfig {
 	}
 	if cfg.CacheTTL != "" {
 		eff.CacheTTL = cfg.CacheTTL
+	}
+	if cfg.Protocol != "" {
+		eff.Protocol = cfg.Protocol
+	}
+	if cfg.TLSServerName != "" {
+		eff.TLSServerName = cfg.TLSServerName
 	}
 	if cfg.Servers != nil {
 		eff.Servers = cfg.Servers

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -41,7 +41,7 @@ type effectiveConfig struct {
 	Concurrency   int         `json:"concurrency"     yaml:"concurrency"`
 	EDNS0Size     uint16      `json:"edns0_size"      yaml:"edns0_size"`
 	Protocol      string      `json:"protocol"        yaml:"protocol"`
-	TLSServerName string      `json:"tls_server_name,omitempty" yaml:"tls_server_name,omitempty"`
+	TLSServerName string      `json:"tls_server_name" yaml:"tls_server_name"`
 	TLSSkipVerify bool        `json:"tls_skip_verify" yaml:"tls_skip_verify"`
 	Servers       []ServerDef `json:"servers"         yaml:"servers"`
 }
@@ -138,7 +138,7 @@ func runConfig(cmd *cobra.Command, _ []string) error {
 	// neither json.Marshal nor yaml.Marshal can fail for these types.
 	var output []byte
 	if jsonMode {
-		output, _ = json.Marshal(env)
+		output, _ = json.MarshalIndent(env, "", "  ")
 		output = append(output, '\n')
 	} else {
 		output, _ = yaml.Marshal(env)

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -255,13 +255,17 @@ func TestRunConfig_MergeConfig_AllFields(t *testing.T) {
 	concurrency := 75
 	edns := uint16(2048)
 	disableCache := true
+	skipVerify := true
 	cfg := &Config{
-		Timeout:      "15s",
-		MaxRetries:   &retries,
-		CacheTTL:     "20m",
-		DisableCache: &disableCache,
-		Concurrency:  &concurrency,
-		EDNS0Size:    &edns,
+		Timeout:       "15s",
+		MaxRetries:    &retries,
+		CacheTTL:      "20m",
+		DisableCache:  &disableCache,
+		Concurrency:   &concurrency,
+		EDNS0Size:     &edns,
+		Protocol:      "tcp",
+		TLSServerName: "dns.example.com",
+		TLSSkipVerify: &skipVerify,
 		Servers: []ServerDef{
 			{Address: "1.1.1.1", Keyword: "test", QueryType: "A"},
 		},
@@ -285,6 +289,15 @@ func TestRunConfig_MergeConfig_AllFields(t *testing.T) {
 	}
 	if merged.EDNS0Size != 2048 {
 		t.Errorf("expected edns0_size=2048, got %d", merged.EDNS0Size)
+	}
+	if merged.Protocol != "tcp" {
+		t.Errorf("expected protocol=tcp, got %q", merged.Protocol)
+	}
+	if merged.TLSServerName != "dns.example.com" {
+		t.Errorf("expected tls_server_name=dns.example.com, got %q", merged.TLSServerName)
+	}
+	if !merged.TLSSkipVerify {
+		t.Error("expected tls_skip_verify=true")
 	}
 	if len(merged.Servers) != 1 || merged.Servers[0].Address != "1.1.1.1" {
 		t.Errorf("unexpected servers: %v", merged.Servers)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -213,3 +213,50 @@ func TestBuildChecker_DisableCacheNoCache(t *testing.T) {
 	// FlushCache must not panic when cache is nil.
 	assert.NotPanics(t, func() { checker.FlushCache() })
 }
+
+func TestConfig_ToOptions_ParseProtocol(t *testing.T) {
+	// Set: returns WithProtocol option
+	cfg := &Config{Protocol: "tcp"}
+	opts, err := cfg.toOptions()
+	require.NoError(t, err)
+	require.Len(t, opts, 1, "expected one option for Protocol=tcp")
+
+	// Empty: no option
+	cfg2 := &Config{}
+	opts2, err := cfg2.toOptions()
+	require.NoError(t, err)
+	assert.Empty(t, opts2)
+}
+
+func TestConfig_ToOptions_ParseTLSServerName(t *testing.T) {
+	cfg := &Config{TLSServerName: "dns.example.com"}
+	opts, err := cfg.toOptions()
+	require.NoError(t, err)
+	require.Len(t, opts, 1)
+
+	cfg2 := &Config{}
+	opts2, err := cfg2.toOptions()
+	require.NoError(t, err)
+	assert.Empty(t, opts2)
+}
+
+func TestConfig_ToOptions_ParseTLSSkipVerify(t *testing.T) {
+	t1 := true
+	cfg := &Config{TLSSkipVerify: &t1}
+	opts, err := cfg.toOptions()
+	require.NoError(t, err)
+	require.Len(t, opts, 1)
+
+	// false → no option
+	f := false
+	cfg2 := &Config{TLSSkipVerify: &f}
+	opts2, err := cfg2.toOptions()
+	require.NoError(t, err)
+	assert.Empty(t, opts2)
+
+	// nil → no option
+	cfg3 := &Config{}
+	opts3, err := cfg3.toOptions()
+	require.NoError(t, err)
+	assert.Empty(t, opts3)
+}

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -5,10 +5,11 @@
 
 // Package cli implements the nawala command-line interface.
 //
-// It provides a Cobra-based CLI with two subcommands:
+// It provides a Cobra-based CLI with three subcommands:
 //
-//   - check — check whether domains are blocked by Indonesian ISP DNS filters
+//   - check  — check whether domains are blocked by Indonesian ISP DNS filters
 //   - status — display the health and latency of configured DNS servers
+//   - config — print the effective configuration (defaults or loaded file)
 //
 // The root command delegates to check when positional domain arguments are
 // provided, so "nawala google.com" is equivalent to "nawala check google.com".
@@ -18,21 +19,37 @@
 // A JSON or YAML configuration file can be passed via the --config (-c) flag.
 // The file format is auto-detected by extension (.json, .yaml, .yml). All
 // fields are optional; unset fields fall through to the nawala SDK defaults.
+// Use "nawala config" to generate a template with all defaults filled in.
 //
-// Example YAML:
+// Example YAML (nawala envelope format):
 //
-//	timeout: 10s
-//	max_retries: 3
-//	cache_ttl: 10m
-//	disable_cache: false
-//	concurrency: 50
-//	servers:
-//	  - address: "180.131.144.144"
-//	    keyword: "internetpositif"
-//	    query_type: "A"
+//	nawala:
+//	  configuration:
+//	    timeout: 10s
+//	    max_retries: 3
+//	    cache_ttl: 10m
+//	    disable_cache: false
+//	    concurrency: 50
+//	    protocol: udp
+//	    tls_server_name: ""
+//	    tls_skip_verify: false
+//	    servers:
+//	      - address: "180.131.144.144"
+//	        keyword: "internetpositif"
+//	        query_type: "A"
 //
 // Set disable_cache: true to disable the built-in in-memory cache entirely.
 // When set, the cache_ttl field has no effect.
+//
+// Set protocol to "udp" (default), "tcp", or "tcp-tls" (DNS over TLS / DoT)
+// to select the DNS transport without needing a custom WithDNSClient.
+// For tcp-tls, two optional TLS fields are available:
+//
+//   - tls_server_name: the TLS identity (cert hostname) to verify against. The server
+//     address (IP) and this name are independent — the IP is the transport destination,
+//     the server name is what TLS verifies the cert against (no IP SAN needed in the cert).
+//   - tls_skip_verify: disables TLS certificate verification entirely. Only for self-signed
+//     certs; never use in production.
 //
 // # Domain Input
 //

--- a/src/nawala/checker.go
+++ b/src/nawala/checker.go
@@ -7,6 +7,7 @@ package nawala
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"sync"
@@ -41,16 +42,19 @@ var defaultServers = []DNSServer{
 // Checker performs DNS-based domain blocking checks against
 // Nawala/Kominfo (now Komdigi) DNS servers.
 type Checker struct {
-	mu          sync.RWMutex
-	servers     []DNSServer
-	timeout     time.Duration
-	maxRetries  int
-	concurrency int
-	cache       Cache
-	cacheSet    bool // true when WithCache was called explicitly (even with nil)
-	cacheTTL    time.Duration
-	edns0Size   uint16
-	dnsClient   *dns.Client
+	mu            sync.RWMutex
+	servers       []DNSServer
+	timeout       time.Duration
+	maxRetries    int
+	concurrency   int
+	cache         Cache
+	cacheSet      bool // true when WithCache was called explicitly (even with nil)
+	cacheTTL      time.Duration
+	edns0Size     uint16
+	dnsProtocol   string // dns.Client.Net value: "udp", "tcp", or "tcp-tls"
+	tlsServerName string // TLS SNI server name override (tcp-tls only)
+	tlsSkipVerify bool   // skip TLS certificate verification (tcp-tls only)
+	dnsClient     *dns.Client
 }
 
 // New creates a new [Checker] with the default Nawala DNS server
@@ -72,6 +76,7 @@ func New(opts ...Option) *Checker {
 		concurrency: defaultConcurrency,
 		edns0Size:   defaultEDNS0Size,
 		cacheTTL:    defaultCacheTTL,
+		dnsProtocol: "udp",
 	}
 	copy(c.servers, defaultServers)
 
@@ -87,10 +92,19 @@ func New(opts ...Option) *Checker {
 
 	// Initialize shared DNS client if not set by WithDNSClient option.
 	if c.dnsClient == nil {
-		c.dnsClient = &dns.Client{
+		client := &dns.Client{
 			Timeout: c.timeout,
-			Net:     "udp",
+			Net:     c.dnsProtocol,
 		}
+		// Build TLS config only for tcp-tls and only when explicitly requested,
+		// so UDP/TCP paths have zero overhead.
+		if c.dnsProtocol == "tcp-tls" && (c.tlsSkipVerify || c.tlsServerName != "") {
+			client.TLSConfig = &tls.Config{
+				InsecureSkipVerify: c.tlsSkipVerify, //nolint:gosec // intentional user opt-in
+				ServerName:         c.tlsServerName,
+			}
+		}
+		c.dnsClient = client
 	}
 
 	return c

--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -1567,3 +1567,97 @@ func TestCheckIDNDomains(t *testing.T) {
 		}
 	})
 }
+
+// TestWithProtocol verifies that WithProtocol sets dnsProtocol correctly
+// and that invalid values are silently ignored (default "udp" kept).
+func TestWithProtocol(t *testing.T) {
+	cases := []struct {
+		proto string
+		want  string
+	}{
+		{"udp", "udp"},
+		{"tcp", "tcp"},
+		{"tcp-tls", "tcp-tls"},
+		{"invalid", "udp"},
+		{"", "udp"},
+	}
+	for _, tc := range cases {
+		c := New(WithProtocol(tc.proto))
+		assert.Equal(t, tc.want, c.dnsProtocol, "proto=%q", tc.proto)
+	}
+}
+
+// TestWithTLSServerName verifies the field is stored and TLS config is populated.
+func TestWithTLSServerName(t *testing.T) {
+	c := New(WithProtocol("tcp-tls"), WithTLSServerName("dns.example.com"))
+	assert.Equal(t, "dns.example.com", c.tlsServerName)
+	require.NotNil(t, c.dnsClient.TLSConfig, "TLSConfig should be set for tcp-tls + server name")
+	assert.Equal(t, "dns.example.com", c.dnsClient.TLSConfig.ServerName)
+	assert.False(t, c.dnsClient.TLSConfig.InsecureSkipVerify)
+}
+
+// TestWithTLSSkipVerify verifies InsecureSkipVerify is propagated to dns.Client.TLSConfig.
+func TestWithTLSSkipVerify(t *testing.T) {
+	c := New(WithProtocol("tcp-tls"), WithTLSSkipVerify())
+	assert.True(t, c.tlsSkipVerify)
+	require.NotNil(t, c.dnsClient.TLSConfig, "TLSConfig should be set for tcp-tls + skip-verify")
+	assert.True(t, c.dnsClient.TLSConfig.InsecureSkipVerify)
+}
+
+// TestWithTLSOptions_NoEffectWithoutTCPTLS verifies that TLS options do not
+// create a TLSConfig when the protocol is udp or tcp.
+func TestWithTLSOptions_NoEffectWithoutTCPTLS(t *testing.T) {
+	c := New(WithProtocol("udp"), WithTLSSkipVerify(), WithTLSServerName("example.com"))
+	assert.Nil(t, c.dnsClient.TLSConfig, "TLSConfig must be nil for UDP even with TLS options set")
+}
+
+// TestWithProtocol_TCP runs an actual DNS query over TCP to exercise that
+// code path through queryDNS.
+func TestWithProtocol_TCP(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Answer = append(m.Answer, &dns.A{
+			Hdr: dns.RR_Header{
+				Name:   r.Question[0].Name,
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+				Ttl:    60,
+			},
+			A: net.ParseIP("127.0.0.1"),
+		})
+		_ = w.WriteMsg(m)
+	})
+	srv := &dns.Server{Listener: ln, Handler: handler, Net: "tcp"}
+	go func() { _ = srv.ActivateAndServe() }()
+	time.Sleep(30 * time.Millisecond)
+
+	c := New(
+		WithProtocol("tcp"),
+		WithServers([]DNSServer{
+			{Address: ln.Addr().String(), Keyword: "test", QueryType: "A"},
+		}),
+		WithTimeout(3*time.Second),
+	)
+	assert.Equal(t, "tcp", c.dnsClient.Net)
+
+	result, err := c.CheckOne(context.Background(), "example.com")
+	require.NoError(t, err)
+	assert.NoError(t, result.Error)
+}
+
+// TestWithProtocol_TLSSkipVerifyAndServerName verifies both TLS options combine.
+func TestWithProtocol_TLSSkipVerifyAndServerName(t *testing.T) {
+	c := New(
+		WithProtocol("tcp-tls"),
+		WithTLSSkipVerify(),
+		WithTLSServerName("custom.dns"),
+	)
+	require.NotNil(t, c.dnsClient.TLSConfig)
+	assert.True(t, c.dnsClient.TLSConfig.InsecureSkipVerify)
+	assert.Equal(t, "custom.dns", c.dnsClient.TLSConfig.ServerName)
+}

--- a/src/nawala/docs.go
+++ b/src/nawala/docs.go
@@ -112,11 +112,14 @@
 //	    // Limit concurrent checks to 50 goroutines.
 //	    nawala.WithConcurrency(50),
 //
-//	    // Use a custom DNS client (e.g., TCP or DNS-over-TLS).
+//	    // Use a custom DNS client (e.g., custom dialer or advanced TLS).
 //	    nawala.WithDNSClient(&dns.Client{
 //	        Timeout: 10 * time.Second,
 //	        Net:     "tcp-tls",
 //	    }),
+//
+//	    // Or simply switch protocol without replacing the client.
+//	    nawala.WithProtocol("tcp-tls"),
 //
 //	    // Set custom EDNS0 size (default is 1232 to prevent fragmentation).
 //	    nawala.WithEDNS0Size(4096),
@@ -130,7 +133,13 @@
 //   - [WithCache]             — Custom Cache implementation; pass nil to disable
 //   - [WithConcurrency]       — Max concurrent DNS checks, semaphore size (default: 100)
 //   - [WithEDNS0Size]         — EDNS0 UDP buffer size, prevents fragmentation (default: 1232)
-//   - [WithDNSClient]         — Custom client for TCP, TLS, or custom dialer
+//   - [WithProtocol]          — DNS transport: "udp" (default), "tcp", or "tcp-tls" (DoT)
+//   - [WithTLSServerName]     — SNI server name for tcp-tls; required when the server address is
+//     an IP and the cert is issued for a hostname (works with trusted CA certs; set
+//     tls_skip_verify: false for full verification)
+//   - [WithTLSSkipVerify]     — Disable TLS cert verification for tcp-tls (only for self-signed
+//     certs where no valid server name can be provided; never use in production)
+//   - [WithDNSClient]         — Custom client for full transport control (TCP, TLS, dialer)
 //   - [WithServer]            — (Deprecated: use [Checker.SetServers] for hot-reloading) Add or replace a single DNS server
 //   - [WithServers]           — Replace all DNS servers (default: Nawala servers)
 //   - [Checker.SetServers]    — Hot-reload: Add or replace servers at runtime safely

--- a/src/nawala/option.go
+++ b/src/nawala/option.go
@@ -192,6 +192,70 @@ func WithEDNS0Size(size uint16) Option {
 	}
 }
 
+// WithProtocol sets the DNS transport protocol used by the default DNS client.
+// The default is "udp".
+//
+// Valid values:
+//
+//   - "udp"     — standard DNS over UDP (default; [RFC 1035])
+//   - "tcp"     — DNS over TCP ([RFC 1035])
+//   - "tcp-tls" — DNS over TLS, also known as DoT ([RFC 7858])
+//
+// Invalid values are ignored and the default "udp" is kept.
+// This option has no effect if a custom DNS client is set via [WithDNSClient],
+// as the custom client's own Net configuration takes precedence.
+//
+// [RFC 1035]: https://www.rfc-editor.org/rfc/rfc1035.html
+// [RFC 7858]: https://www.rfc-editor.org/rfc/rfc7858.html
+func WithProtocol(net string) Option {
+	return func(c *Checker) {
+		switch net {
+		case "udp", "tcp", "tcp-tls":
+			c.dnsProtocol = net
+		}
+	}
+}
+
+// WithTLSServerName overrides the TLS server name (SNI) used when connecting
+// to a DoT (DNS-over-TLS) server.
+//
+// The server address (IP) and server name are independent. You connect to the IP
+// as the transport destination, while the server name declares the TLS identity
+// to verify the certificate against. The cert does not need to contain the IP.
+// This is identical to how HTTPS works: connect to a resolved IP, verify the
+// cert against the hostname.
+//
+// Example — IP address with a trusted CA cert:
+//
+//	c := nawala.New(
+//	    nawala.WithProtocol("tcp-tls"),
+//	    nawala.WithTLSServerName("dns.example.com"), // cert subject
+//	    // tls_skip_verify: false (default) — full cert verification
+//	)
+//
+// Only applies when [WithProtocol]("tcp-tls") is in use. Has no effect for
+// "udp" or "tcp" protocols, or when a custom client is set via [WithDNSClient].
+func WithTLSServerName(name string) Option {
+	return func(c *Checker) {
+		c.tlsServerName = name
+	}
+}
+
+// WithTLSSkipVerify disables TLS certificate verification when connecting to a
+// DoT (DNS-over-TLS) server.
+//
+// WARNING: this disables all TLS security guarantees. Only use this in
+// controlled environments (e.g. testing with a self-signed certificate).
+// Never use this in production against untrusted networks.
+//
+// Only applies when [WithProtocol]("tcp-tls") is in use. Has no effect for
+// "udp" or "tcp" protocols, or when a custom client is set via [WithDNSClient].
+func WithTLSSkipVerify() Option {
+	return func(c *Checker) {
+		c.tlsSkipVerify = true
+	}
+}
+
 // DeleteServers removes one or more servers from the checker's active
 // configuration at runtime. It is concurrency-safe and will safely remove
 // servers identified by their Address field.


### PR DESCRIPTION
- [+] Add `WithProtocol`, `WithTLSServerName`, `WithTLSSkipVerify` options to SDK Checker
- [+] Implement conditional TLSConfig in default dns.Client for "tcp-tls" protocol
- [+] Extend CLI Config struct and parsing for `protocol`, `tls_server_name`, `tls_skip_verify`
- [+] Add `nawala config` subcommand to inspect/print effective configuration (JSON/YAML)
- [+] Update README.md, README.id.md, and godoc with new examples, envelope format, and docs
- [+] Add comprehensive tests for new SDK options, CLI config parsing, and TCP/DoT paths