### PR TITLE
fix(nawala): use correct default port for DoT and preserve custom ports

### DIFF
--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -1661,3 +1661,26 @@ func TestWithProtocol_TLSSkipVerifyAndServerName(t *testing.T) {
 	assert.True(t, c.dnsClient.TLSConfig.InsecureSkipVerify)
 	assert.Equal(t, "custom.dns", c.dnsClient.TLSConfig.ServerName)
 }
+
+// TestQueryDNS_CustomPort verifies that if a user provides a custom port in the server address,
+// the default port logic (53 or 853) does not override it.
+func TestQueryDNS_CustomPort(t *testing.T) {
+	// We don't need a real server, we just want to ensure it tries to dial the right port
+	// and fails with a connection error instead of changing the port.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	q := dnsQuery{
+		client:    &dns.Client{Net: "tcp-tls"},
+		domain:    "example.com",
+		server:    "127.0.0.1:9853", // Custom port
+		qtype:     dns.TypeA,
+		edns0Size: 1232,
+	}
+
+	_, err := queryDNS(ctx, q)
+	require.Error(t, err)
+
+	// The error should mention the custom port 9853, proving it didn't get overwritten to 853.
+	assert.Contains(t, err.Error(), "127.0.0.1:9853", "Should attempt to dial the custom port")
+}

--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -1077,7 +1077,6 @@ func TestDNSQueryPortLogic(t *testing.T) {
 	addr, cleanup := startTestDNSServer(t, handler)
 	defer cleanup()
 
-	customClient := &dns.Client{Timeout: 1 * time.Second}
 	ctx := context.Background()
 
 	// Extract port from the dummy server
@@ -1149,6 +1148,12 @@ func TestDNSQueryPortLogic(t *testing.T) {
 			wantAddr:   "[fe80::1%eth0]:" + port,
 			skipOS:     "windows",
 		},
+		{
+			// Explicitly tests that if protocol is tcp-tls, default port becomes 853.
+			name:       "Default port fallback for tcp-tls",
+			serverAddr: "127.0.0.1",
+			wantAddr:   "127.0.0.1:853",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1157,8 +1162,16 @@ func TestDNSQueryPortLogic(t *testing.T) {
 				t.Skipf("skipped on %s: IPv6 zone IDs use platform-specific interface names", tt.skipOS)
 			}
 
+			// If testing tcp-tls fallback, assign tcp-tls to the client specifically for this test case
+			clientNet := "udp"
+			if tt.name == "Default port fallback for tcp-tls" {
+				clientNet = "tcp-tls"
+			}
+
+			testClient := &dns.Client{Timeout: 1 * time.Second, Net: clientNet}
+
 			q := dnsQuery{
-				client:    customClient,
+				client:    testClient,
 				domain:    "example.com",
 				server:    tt.serverAddr,
 				qtype:     dns.TypeA,

--- a/src/nawala/dns.go
+++ b/src/nawala/dns.go
@@ -73,7 +73,11 @@ func queryDNS(ctx context.Context, q dnsQuery) (*dns.Msg, error) {
 		// so JoinHostPort can correctly re-add them along with the port.
 		server = strings.TrimPrefix(server, "[")
 		server = strings.TrimSuffix(server, "]")
-		server = net.JoinHostPort(server, "53")
+		defaultPort := "53"
+		if q.client != nil && q.client.Net == "tcp-tls" {
+			defaultPort = "853"
+		}
+		server = net.JoinHostPort(server, defaultPort)
 	}
 
 	resp, _, err := q.client.ExchangeContext(ctx, msg, server)


### PR DESCRIPTION
- [+] Set default port to 853 for tcp-tls (DoT) network instead of 53
- [+] Add test to verify custom ports in server addresses are preserved