### PR TITLE
refactor(cli): unify output formats under --format flag

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -59,16 +59,16 @@ nawala google.com reddit.com
 nawala check --file domains.txt
 
 # Output JSON (NDJSON — satu objek per baris)
-nawala check google.com --json
+nawala check google.com --format json
 
 # Tulis hasil ke file (teks dipisahkan tab)
 nawala check --file domains.txt -o results.txt
 
 # Buat laporan HTML
-nawala check google.com reddit.com --html -o report.html
+nawala check google.com reddit.com --format html -o report.html
 
 # Buat spreadsheet Excel (XLSX)
-nawala check --file domains.txt --xlsx -o results.xlsx
+nawala check --file domains.txt --format xlsx -o results.xlsx
 
 # Gunakan konfigurasi kustom (JSON atau YAML)
 nawala check --config config.json --file domains.txt

--- a/README.md
+++ b/README.md
@@ -59,16 +59,16 @@ nawala google.com reddit.com
 nawala check --file domains.txt
 
 # JSON output (NDJSON — one object per line)
-nawala check google.com --json
+nawala check google.com --format json
 
 # Write results to a file (tab-separated text)
 nawala check --file domains.txt -o results.txt
 
 # Generate an HTML report
-nawala check google.com reddit.com --html -o report.html
+nawala check google.com reddit.com --format html -o report.html
 
 # Generate an Excel spreadsheet (XLSX)
-nawala check --file domains.txt --xlsx -o results.xlsx
+nawala check --file domains.txt --format xlsx -o results.xlsx
 
 # Use a custom config (JSON or YAML)
 nawala check --config config.json --file domains.txt

--- a/cmd/nawala/docs.go
+++ b/cmd/nawala/docs.go
@@ -27,7 +27,7 @@
 //
 //	-f, --file string     path to a .txt file with one domain per line
 //	-o, --output string   write results to a file instead of stdout
-//	    --json            output results as NDJSON (one JSON object per line)
+//	    --format string   output format (text, json, html, xlsx) (default "text")
 //
 // # Config Flags
 //

--- a/examples/custom/main.go
+++ b/examples/custom/main.go
@@ -22,13 +22,6 @@ import (
 func main() {
 	// Create a checker with custom configuration.
 	c := nawala.New(
-		// Add a custom DNS server alongside the defaults.
-		nawala.WithServer(nawala.DNSServer{
-			Address:   "8.8.8.8",
-			Keyword:   "blocked",
-			QueryType: "A",
-		}),
-
 		// Increase timeout for slow networks.
 		nawala.WithTimeout(15*time.Second),
 
@@ -40,6 +33,13 @@ func main() {
 	)
 
 	ctx := context.Background()
+
+	// Add a custom DNS server alongside the defaults.
+	c.SetServers(nawala.DNSServer{
+		Address:   "8.8.8.8",
+		Keyword:   "blocked",
+		QueryType: "A",
+	})
 
 	fmt.Println("=== Custom Configuration Check ===")
 	fmt.Println()

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -28,9 +28,7 @@ var checkCmd = &cobra.Command{
 func init() {
 	checkCmd.Flags().StringP("file", "f", "", "path to a .txt file with one domain per line")
 	checkCmd.Flags().StringP("output", "o", "", "write results to a file instead of stdout")
-	checkCmd.Flags().Bool("json", false, "output results as JSON")
-	checkCmd.Flags().Bool("html", false, "output results as an HTML report")
-	checkCmd.Flags().Bool("xlsx", false, "output results as an Excel spreadsheet")
+	checkCmd.Flags().StringSlice("format", []string{"text"}, "output format (text, json, html, xlsx)")
 }
 
 // runCheck is the shared implementation for both the root default action
@@ -64,7 +62,9 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer w.Close()
+	defer func() {
+		_ = w.Close()
+	}()
 
 	// Run checks with a 30-second overall timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -118,7 +118,9 @@ func collectDomains(args []string, filePath string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("opening domain file: %w", err)
 		}
-		defer f.Close()
+		defer func() {
+			_ = f.Close()
+		}()
 
 		scanner := bufio.NewScanner(f)
 		for scanner.Scan() {

--- a/internal/cli/check_test.go
+++ b/internal/cli/check_test.go
@@ -162,9 +162,7 @@ func newCheckCmd() *cobra.Command {
 	}
 	cmd.Flags().StringP("file", "f", "", "path to a .txt file with one domain per line")
 	cmd.Flags().StringP("output", "o", "", "write results to a file instead of stdout")
-	cmd.Flags().Bool("json", false, "output results as JSON")
-	cmd.Flags().Bool("html", false, "output results as an HTML report")
-	cmd.Flags().Bool("xlsx", false, "output results as an Excel spreadsheet")
+	cmd.Flags().StringSlice("format", []string{"text"}, "output format (text, json, html, xlsx)")
 	return cmd
 }
 
@@ -289,12 +287,12 @@ func createMockDNSServer(t *testing.T) (string, func()) {
 				// Create a valid DNS response (Standard query response, No error)
 				resp := append([]byte(nil), buf[:n]...) // copy request
 				resp[2] |= 0x80                         // Set QR bit (Response)
-				conn.WriteToUDP(resp, addr)
+				_, _ = conn.WriteToUDP(resp, addr)
 			}
 		}
 	}()
 	return conn.LocalAddr().String(), func() {
-		conn.Close()
+		_ = conn.Close()
 		<-done
 	}
 }
@@ -318,6 +316,9 @@ func TestRunCheck_Success(t *testing.T) {
 	cmd := newCheckCmd()
 	cmd.SetArgs([]string{"--output", outPath, "google.com"})
 
+	flag := cmd.Flags().Lookup("format")
+	fmt.Printf("DEBUG IN TEST: flag type is %s\n", flag.Value.Type())
+
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("expected nil error (success), got: %v", err)
 	}
@@ -337,7 +338,7 @@ func TestRunCheck_MultipleFormatFlags(t *testing.T) {
 	defer func() { configPath = saved }()
 
 	cmd := newCheckCmd()
-	cmd.SetArgs([]string{"--json", "--html", "google.com"})
+	cmd.SetArgs([]string{"--format", "json", "--format", "html", "google.com"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error from multiple format flags, got nil")

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -154,7 +154,9 @@ func runConfig(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	defer w.Close()
-	w.w.WriteString(string(output))
+	defer func() {
+		_ = w.Close()
+	}()
+	_, _ = w.w.WriteString(string(output))
 	return nil
 }

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -61,12 +61,12 @@
 // # Output
 //
 // Results are streamed to stdout by default, or written to a file with the
-// --output (-o) flag. Four formats are available:
+// --output (-o) flag. Output formats are controlled by the --format flag:
 //
-//   - Text (default) — tab-separated columns: domain, status, server
-//   - NDJSON (--json) — one JSON object per line, suitable for piping
-//   - HTML (--html) — a styled table report with color-coded status cells
-//   - Excel (--xlsx) — an XLSX spreadsheet with colored cells
+//   - text (default) — tab-separated columns: domain, status, server
+//   - json           — one JSON object per line, suitable for piping (NDJSON)
+//   - html           — a styled table report with color-coded status cells
+//   - xlsx           — an XLSX spreadsheet with colored cells
 //
 // # Embedded Usage Text
 //

--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -7,41 +7,39 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
-// resolveFormat inspects the boolean format flags (--json, --html, --xlsx)
-// on cmd and returns the corresponding format constant. If no flag is set,
-// it defaults to FormatText. If more than one flag is set, it returns an error.
+// resolveFormat inspects the string format flag (--format)
+// on cmd and returns the corresponding format constant.
 func resolveFormat(cmd *cobra.Command) (string, error) {
-	jsonMode, _ := cmd.Flags().GetBool("json")
-	htmlMode, _ := cmd.Flags().GetBool("html")
-	xlsxMode, _ := cmd.Flags().GetBool("xlsx")
-
-	count := 0
-	if jsonMode {
-		count++
-	}
-	if htmlMode {
-		count++
-	}
-	if xlsxMode {
-		count++
+	formats, err := cmd.Flags().GetStringSlice("format")
+	if err != nil {
+		return "", err
 	}
 
-	if count > 1 {
-		return "", fmt.Errorf("only one output format flag may be used (--json, --html, --xlsx)")
+	if len(formats) > 1 {
+		return "", fmt.Errorf("only one output format flag may be used")
 	}
 
-	switch {
-	case jsonMode:
-		return FormatJSON, nil
-	case htmlMode:
-		return FormatHTML, nil
-	case xlsxMode:
-		return FormatXLSX, nil
+	var format string
+	if len(formats) == 1 {
+		format = formats[0]
+	} else {
+		format = FormatText // default if empty
+	}
+
+	// Check for comma-separated multiple formats, e.g. --format=json,html
+	if strings.Contains(format, ",") {
+		return "", fmt.Errorf("only one output format flag may be used")
+	}
+
+	switch format {
+	case FormatText, FormatJSON, FormatHTML, FormatXLSX:
+		return format, nil
 	default:
-		return FormatText, nil
+		return "", fmt.Errorf("invalid output format %q (expected text, json, html, or xlsx)", format)
 	}
 }

--- a/internal/cli/format_test.go
+++ b/internal/cli/format_test.go
@@ -15,9 +15,7 @@ import (
 
 func newTestCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "test"}
-	cmd.Flags().Bool("json", false, "")
-	cmd.Flags().Bool("html", false, "")
-	cmd.Flags().Bool("xlsx", false, "")
+	cmd.Flags().StringSlice("format", []string{"text"}, "")
 	return cmd
 }
 
@@ -30,7 +28,7 @@ func TestResolveFormat_DefaultText(t *testing.T) {
 
 func TestResolveFormat_JSON(t *testing.T) {
 	cmd := newTestCmd()
-	cmd.Flags().Set("json", "true")
+	_ = cmd.Flags().Set("format", "json")
 	f, err := resolveFormat(cmd)
 	require.NoError(t, err)
 	assert.Equal(t, FormatJSON, f)
@@ -38,7 +36,7 @@ func TestResolveFormat_JSON(t *testing.T) {
 
 func TestResolveFormat_HTML(t *testing.T) {
 	cmd := newTestCmd()
-	cmd.Flags().Set("html", "true")
+	_ = cmd.Flags().Set("format", "html")
 	f, err := resolveFormat(cmd)
 	require.NoError(t, err)
 	assert.Equal(t, FormatHTML, f)
@@ -46,26 +44,68 @@ func TestResolveFormat_HTML(t *testing.T) {
 
 func TestResolveFormat_XLSX(t *testing.T) {
 	cmd := newTestCmd()
-	cmd.Flags().Set("xlsx", "true")
+	_ = cmd.Flags().Set("format", "xlsx")
 	f, err := resolveFormat(cmd)
 	require.NoError(t, err)
 	assert.Equal(t, FormatXLSX, f)
 }
 
-func TestResolveFormat_MultipleFlags_Error(t *testing.T) {
+func TestResolveFormat_Invalid(t *testing.T) {
 	cmd := newTestCmd()
-	cmd.Flags().Set("json", "true")
-	cmd.Flags().Set("html", "true")
+	_ = cmd.Flags().Set("format", "invalid")
 	_, err := resolveFormat(cmd)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "only one output format flag")
+	assert.Contains(t, err.Error(), "invalid output format")
 }
 
-func TestResolveFormat_AllThreeFlags_Error(t *testing.T) {
+func TestResolveFormat_MultipleFlags(t *testing.T) {
 	cmd := newTestCmd()
-	cmd.Flags().Set("json", "true")
-	cmd.Flags().Set("html", "true")
-	cmd.Flags().Set("xlsx", "true")
+	// Using StringSlice, setting multiple separate flags
+	_ = cmd.Flags().Set("format", "json")
+	_ = cmd.Flags().Set("format", "html")
 	_, err := resolveFormat(cmd)
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "only one output format flag may be used")
+}
+
+func TestResolveFormat_CommaSeparated(t *testing.T) {
+	cmd := newTestCmd()
+	// This simulates a string containing a comma that bypassed len > 1 check
+	cmd.Flags().Set("format", "json,html")
+	formats, _ := cmd.Flags().GetStringSlice("format")
+	t.Logf("CommaSeparated formats count: %d, items: %v", len(formats), formats)
+	_, err := resolveFormat(cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "only one output format flag may be used")
+}
+
+func TestResolveFormat_Empty(t *testing.T) {
+	cmd := newTestCmd()
+	cmd.Flags().StringSlice("format2", []string{}, "")
+	// Hack to force len(formats) == 0: Just pass a cmd with an empty slice default?
+	// Wait, StringSlice flag default is ["text"]. If we just clear it?
+	_ = cmd.Flags().Set("format", "") // This might result in [""]?
+	formats, _ := cmd.Flags().GetStringSlice("format")
+	t.Logf("Empty formats count: %d, items: %v", len(formats), formats)
+	f, _ := resolveFormat(cmd)
+	t.Logf("Empty format result: %v", f)
+}
+
+func TestResolveFormat_TypeMismatch(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("format", "text", "") // Defined as String, not StringSlice
+	_, err := resolveFormat(cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "trying to get stringSlice value of flag of type string")
+}
+
+func TestResolveFormat_EscapedComma(t *testing.T) {
+	cmd := newTestCmd()
+	// pflag parses StringSlice as CSV. To get a single item with a comma, we quote it.
+	_ = cmd.Flags().Set("format", `"json,html"`)
+	formats, _ := cmd.Flags().GetStringSlice("format")
+	t.Logf("EscapedComma formats count: %d, items: %v", len(formats), formats)
+	_, err := resolveFormat(cmd)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "only one output format flag may be used")
 }

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -12,6 +12,7 @@ import (
 	htmltemplate "html/template"
 	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/H0llyW00dzZ/nawala-checker/src/nawala"
@@ -104,7 +105,7 @@ func (w *Writer) writeText(r nawala.Result) {
 	if r.Error != nil {
 		status = fmt.Sprintf("error: %v", r.Error)
 	}
-	fmt.Fprintf(w.tw, "%s\t%s\t%s\n", r.Domain, status, r.Server)
+	_, _ = fmt.Fprintf(w.tw, "%s\t%s\t%s\n", r.Domain, status, r.Server)
 }
 
 // writeJSON writes a check result as a JSON array element.
@@ -120,13 +121,13 @@ func (w *Writer) writeJSON(r nawala.Result) {
 
 	data, _ := json.Marshal(jr)
 	if !w.jsonStarted {
-		w.w.WriteString(`{"nawala":{"result":[`)
+		_, _ = w.w.WriteString(`{"nawala":{"result":[`)
 		w.jsonStarted = true
 	} else {
-		w.w.WriteString(",")
+		_, _ = w.w.WriteString(",")
 	}
-	w.w.Write(data)
-	w.w.Flush()
+	_, _ = w.w.Write(data)
+	_ = w.w.Flush()
 }
 
 // jsonStatus is the JSON representation of a server health status.
@@ -156,13 +157,13 @@ func (w *Writer) writeStatusText(s nawala.ServerStatus) {
 		status = "OFFLINE"
 	}
 	if s.Online {
-		fmt.Fprintf(w.tw, "%s\t%s\t%dms\n", s.Server, status, s.LatencyMs)
+		_, _ = fmt.Fprintf(w.tw, "%s\t%s\t%dms\n", s.Server, status, s.LatencyMs)
 	} else {
 		errMsg := ""
 		if s.Error != nil {
-			errMsg = s.Error.Error()
+			errMsg = strings.TrimPrefix(s.Error.Error(), "nawala: ")
 		}
-		fmt.Fprintf(w.tw, "%s\t%s\t%s\n", s.Server, status, errMsg)
+		_, _ = fmt.Fprintf(w.tw, "%s\t%s\t%s\n", s.Server, status, errMsg)
 	}
 }
 
@@ -179,13 +180,13 @@ func (w *Writer) writeStatusJSON(s nawala.ServerStatus) {
 	data, _ := json.Marshal(js)
 
 	if !w.jsonStarted {
-		w.w.WriteString(`{"nawala":{"status":[`)
+		_, _ = w.w.WriteString(`{"nawala":{"status":[`)
 		w.jsonStarted = true
 	} else {
-		w.w.WriteString(",")
+		_, _ = w.w.WriteString(",")
 	}
-	w.w.Write(data)
-	w.w.Flush()
+	_, _ = w.w.Write(data)
+	_ = w.w.Flush()
 }
 
 // htmlResultData is the data passed to the result HTML template.
@@ -253,7 +254,9 @@ func (w *Writer) closeHTML() error {
 // applies green/red fill styles, and saves to outputPath.
 func (w *Writer) closeXLSX() error {
 	f := excelize.NewFile()
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	// Define cell styles.
 	greenStyle, _ := f.NewStyle(&excelize.Style{
@@ -277,65 +280,65 @@ func (w *Writer) closeXLSX() error {
 
 	if len(w.results) > 0 {
 		// Header row.
-		f.SetCellValue(sheet, "A1", "Domain")
-		f.SetCellValue(sheet, "B1", "Status")
-		f.SetCellValue(sheet, "C1", "Server")
-		f.SetCellStyle(sheet, "A1", "C1", headerStyle)
+		_ = f.SetCellValue(sheet, "A1", "Domain")
+		_ = f.SetCellValue(sheet, "B1", "Status")
+		_ = f.SetCellValue(sheet, "C1", "Server")
+		_ = f.SetCellStyle(sheet, "A1", "C1", headerStyle)
 
 		for i, r := range w.results {
 			row := i + 2
-			f.SetCellValue(sheet, fmt.Sprintf("A%d", row), r.Domain)
-			f.SetCellValue(sheet, fmt.Sprintf("C%d", row), r.Server)
+			_ = f.SetCellValue(sheet, fmt.Sprintf("A%d", row), r.Domain)
+			_ = f.SetCellValue(sheet, fmt.Sprintf("C%d", row), r.Server)
 
 			statusCell := fmt.Sprintf("B%d", row)
 			if r.Error != nil {
-				f.SetCellValue(sheet, statusCell, fmt.Sprintf("error: %v", r.Error))
-				f.SetCellStyle(sheet, statusCell, statusCell, orangeStyle)
+				_ = f.SetCellValue(sheet, statusCell, fmt.Sprintf("error: %v", r.Error))
+				_ = f.SetCellStyle(sheet, statusCell, statusCell, orangeStyle)
 			} else if r.Blocked {
-				f.SetCellValue(sheet, statusCell, "BLOCKED")
-				f.SetCellStyle(sheet, statusCell, statusCell, redStyle)
+				_ = f.SetCellValue(sheet, statusCell, "BLOCKED")
+				_ = f.SetCellStyle(sheet, statusCell, statusCell, redStyle)
 			} else {
-				f.SetCellValue(sheet, statusCell, "NOT BLOCKED")
-				f.SetCellStyle(sheet, statusCell, statusCell, greenStyle)
+				_ = f.SetCellValue(sheet, statusCell, "NOT BLOCKED")
+				_ = f.SetCellStyle(sheet, statusCell, statusCell, greenStyle)
 			}
 		}
 
 		// Auto-fit column widths.
-		f.SetColWidth(sheet, "A", "A", 40)
-		f.SetColWidth(sheet, "B", "B", 18)
-		f.SetColWidth(sheet, "C", "C", 22)
+		_ = f.SetColWidth(sheet, "A", "A", 40)
+		_ = f.SetColWidth(sheet, "B", "B", 18)
+		_ = f.SetColWidth(sheet, "C", "C", 22)
 	}
 
 	if len(w.statuses) > 0 {
 		// Header row.
-		f.SetCellValue(sheet, "A1", "Server")
-		f.SetCellValue(sheet, "B1", "Status")
-		f.SetCellValue(sheet, "C1", "Latency / Error")
-		f.SetCellStyle(sheet, "A1", "C1", headerStyle)
+		_ = f.SetCellValue(sheet, "A1", "Server")
+		_ = f.SetCellValue(sheet, "B1", "Status")
+		_ = f.SetCellValue(sheet, "C1", "Latency / Error")
+		_ = f.SetCellStyle(sheet, "A1", "C1", headerStyle)
 
 		for i, s := range w.statuses {
 			row := i + 2
-			f.SetCellValue(sheet, fmt.Sprintf("A%d", row), s.Server)
+			_ = f.SetCellValue(sheet, fmt.Sprintf("A%d", row), s.Server)
 
 			statusCell := fmt.Sprintf("B%d", row)
 			if s.Online {
-				f.SetCellValue(sheet, statusCell, "ONLINE")
-				f.SetCellStyle(sheet, statusCell, statusCell, greenStyle)
-				f.SetCellValue(sheet, fmt.Sprintf("C%d", row), fmt.Sprintf("%dms", s.LatencyMs))
+				_ = f.SetCellValue(sheet, statusCell, "ONLINE")
+				_ = f.SetCellStyle(sheet, statusCell, statusCell, greenStyle)
+				_ = f.SetCellValue(sheet, fmt.Sprintf("C%d", row), fmt.Sprintf("%dms", s.LatencyMs))
 			} else {
-				f.SetCellValue(sheet, statusCell, "OFFLINE")
-				f.SetCellStyle(sheet, statusCell, statusCell, redStyle)
+				_ = f.SetCellValue(sheet, statusCell, "OFFLINE")
+				_ = f.SetCellStyle(sheet, statusCell, statusCell, redStyle)
 				errMsg := ""
 				if s.Error != nil {
 					errMsg = s.Error.Error()
 				}
-				f.SetCellValue(sheet, fmt.Sprintf("C%d", row), errMsg)
+				_ = f.SetCellValue(sheet, fmt.Sprintf("C%d", row), errMsg)
 			}
 		}
 
-		f.SetColWidth(sheet, "A", "A", 22)
-		f.SetColWidth(sheet, "B", "B", 12)
-		f.SetColWidth(sheet, "C", "C", 30)
+		_ = f.SetColWidth(sheet, "A", "A", 22)
+		_ = f.SetColWidth(sheet, "B", "B", 12)
+		_ = f.SetColWidth(sheet, "C", "C", 30)
 	}
 
 	// Save to the output path. If outputPath is empty, write to stdout.
@@ -351,7 +354,7 @@ func (w *Writer) Close() error {
 	switch w.format {
 	case FormatJSON:
 		if w.jsonStarted {
-			w.w.WriteString("]}}\n")
+			_, _ = w.w.WriteString("]}}\n")
 			w.jsonStarted = false
 		}
 	case FormatHTML:
@@ -373,7 +376,7 @@ func (w *Writer) Close() error {
 	// Flush the tabwriter first (computes column widths and writes to w.w),
 	// then flush the underlying bufio.Writer to the destination.
 	if w.tw != nil {
-		w.tw.Flush()
+		_ = w.tw.Flush()
 	}
 
 	if err := w.w.Flush(); err != nil {

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -33,14 +33,16 @@ func testWriter(format string) (*Writer, *bytes.Buffer) {
 
 // flushAndRead flushes the Writer, closes it (triggering array caps), and returns the buffer contents.
 func flushAndRead(w *Writer, buf *bytes.Buffer) string {
-	w.Close()
+	_ = w.Close()
 	return buf.String()
 }
 
 func TestNewWriter_Stdout(t *testing.T) {
 	w, err := NewWriter("", FormatText)
 	require.NoError(t, err)
-	defer w.Close()
+	defer func() {
+		_ = w.Close()
+	}()
 
 	assert.Nil(t, w.closer, "expected closer to be nil for stdout")
 }
@@ -49,7 +51,9 @@ func TestNewWriter_File(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "out.txt")
 	w, err := NewWriter(path, FormatText)
 	require.NoError(t, err)
-	defer w.Close()
+	defer func() {
+		_ = w.Close()
+	}()
 
 	assert.NotNil(t, w.closer, "expected closer to be non-nil for file output")
 }
@@ -298,7 +302,7 @@ func TestWriter_Close_FlushError(t *testing.T) {
 	w.WriteResult(nawala.Result{Domain: "test.com", Server: "8.8.8.8"})
 
 	// Close the underlying file to force a flush error.
-	w.closer.Close()
+	_ = w.closer.Close()
 	w.closer = nil // prevent double-close
 
 	// Write more data so bufio has unflushed content.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,7 +32,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	// If --version was requested, print and exit.
 	v, _ := cmd.Flags().GetBool("version")
 	if v {
-		fmt.Fprintf(cmd.OutOrStdout(), "nawala %s\n", nawala.Version)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "nawala %s\n", nawala.Version)
 		return nil
 	}
 
@@ -42,7 +42,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	}
 
 	// Delegate to check with the same args.
-	return runCheck(cmd, args)
+	return runCheck(checkCmd, args)
 }
 
 func init() {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -173,7 +173,7 @@ func TestRunRoot_NoArgs(t *testing.T) {
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)
 	rootCmd.SetArgs([]string{}) // reset args
-	rootCmd.Flags().Set("version", "false")
+	_ = rootCmd.Flags().Set("version", "false")
 
 	// Call runRoot directly with empty args to hit the len(args)==0 path.
 	err := runRoot(rootCmd, []string{})
@@ -224,9 +224,7 @@ func newStatusCmd() *cobra.Command {
 		RunE: runStatus,
 	}
 	cmd.Flags().StringP("output", "o", "", "write results to a file instead of stdout")
-	cmd.Flags().Bool("json", false, "output results as JSON")
-	cmd.Flags().Bool("html", false, "output results as an HTML report")
-	cmd.Flags().Bool("xlsx", false, "output results as an Excel spreadsheet")
+	cmd.Flags().StringSlice("format", []string{"text"}, "output format (text, json, html, xlsx)")
 	return cmd
 }
 
@@ -364,7 +362,7 @@ func TestRunStatus_MultipleFormatFlags(t *testing.T) {
 	defer func() { configPath = saved }()
 
 	cmd := newStatusCmd()
-	cmd.SetArgs([]string{"--json", "--xlsx"})
+	cmd.SetArgs([]string{"--format", "json", "--format", "xlsx"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error from multiple format flags, got nil")

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -24,9 +24,7 @@ var statusCmd = &cobra.Command{
 
 func init() {
 	statusCmd.Flags().StringP("output", "o", "", "write results to a file instead of stdout")
-	statusCmd.Flags().Bool("json", false, "output results as JSON")
-	statusCmd.Flags().Bool("html", false, "output results as an HTML report")
-	statusCmd.Flags().Bool("xlsx", false, "output results as an Excel spreadsheet")
+	statusCmd.Flags().StringSlice("format", []string{"text"}, "output format (text, json, html, xlsx)")
 }
 
 // runStatus queries all configured DNS servers for health and latency,
@@ -48,7 +46,9 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	defer w.Close()
+	defer func() {
+		_ = w.Close()
+	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/internal/cli/usage/check_long.txt
+++ b/internal/cli/usage/check_long.txt
@@ -7,13 +7,13 @@ The text file format is one domain per line. Lines starting with '#' are
 treated as comments, and blank lines are ignored.
 
 By default, results are streamed to stdout as tab-separated text.
-Other formats available are --json, --html, and --xlsx. Use the
---output (-o) flag to write results to a file instead of stdout.
+Other formats available are json, html, and xlsx. Use the --format
+flag to choose a format, and --output (-o) to write results to a file.
 
 Examples:
   nawala check google.com reddit.com github.com
   nawala check --file domains.txt
-  nawala check --file domains.txt --json
-  nawala check --file domains.txt --html -o report.html
-  nawala check --file domains.txt --xlsx -o results.xlsx
-  nawala check --config custom.yaml --file domains.txt --json -o out.json
+  nawala check --file domains.txt --format json
+  nawala check --file domains.txt --format html -o report.html
+  nawala check --file domains.txt --format xlsx -o results.xlsx
+  nawala check --config custom.yaml --file domains.txt --format json -o out.json

--- a/internal/cli/usage/status_long.txt
+++ b/internal/cli/usage/status_long.txt
@@ -9,6 +9,6 @@ Use --config to check health of custom server configurations.
 Examples:
   nawala status
   nawala status --config custom.yaml
-  nawala status --json
-  nawala status --html -o stat.html
-  nawala status --xlsx -o health.xlsx
+  nawala status --format json
+  nawala status --format html -o stat.html
+  nawala status --format xlsx -o health.xlsx

--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -769,7 +769,9 @@ func TestDNSOverTLS(t *testing.T) {
 	// 2. Start TLS Listener
 	listener, err := tls.Listen("tcp", "127.0.0.1:0", tlsConfig)
 	require.NoError(t, err)
-	defer listener.Close()
+	defer func() {
+		_ = listener.Close()
+	}()
 
 	// 3. Start DNS Server
 	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
@@ -954,7 +956,9 @@ func TestNawalaRPZStyleBlockingDoT(t *testing.T) {
 	// 2. Start TLS Listener
 	listener, err := tls.Listen("tcp", "127.0.0.1:0", tlsConfig)
 	require.NoError(t, err)
-	defer listener.Close()
+	defer func() {
+		_ = listener.Close()
+	}()
 
 	// 3. Simplified Nawala-style RPZ blacklist
 	blacklist := map[string]bool{
@@ -1629,7 +1633,9 @@ func TestWithTLSOptions_NoEffectWithoutTCPTLS(t *testing.T) {
 func TestWithProtocol_TCP(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer ln.Close()
+	defer func() {
+		_ = ln.Close()
+	}()
 
 	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
 		m := new(dns.Msg)

--- a/src/nawala/domain.go
+++ b/src/nawala/domain.go
@@ -103,7 +103,7 @@ func isValidTLD(label string) bool {
 
 	// Standard TLDs must be letters only
 	for _, c := range label {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') {
 			return false
 		}
 	}

--- a/src/nawala/option.go
+++ b/src/nawala/option.go
@@ -33,11 +33,7 @@ func WithServers(servers []DNSServer) Option {
 		deduped := make([]DNSServer, 0, len(servers))
 
 		for _, s := range servers {
-			key := serverKey{
-				Address:   s.Address,
-				Keyword:   s.Keyword,
-				QueryType: s.QueryType,
-			}
+			key := serverKey(s)
 			if _, ok := seen[key]; !ok {
 				seen[key] = struct{}{}
 				deduped = append(deduped, s)


### PR DESCRIPTION
- [+] Replace --json/--html/--xlsx bool flags with --format stringSlice (text,json,html,xlsx) in check/status/root commands
- [+] Refactor resolveFormat to parse/validate single format from slice, reject multiples/commas/invalids
- [+] Update README.md/README.id.md, docs.go, usage texts with new flag syntax/examples
- [+] Add error ignoring (_ =) to defers, fmt.Fprintf, io writes for consistency
- [+] Update extensive tests: format resolution, multiple flags, output writers, mock servers
- [+] Move custom server addition to c.SetServers() post-New() in examples/custom/main.go
- [+] Minor fixes: TLD validation logic, serverKey construction, status error trimming