### PR TITLE
fix(cli): suppress Cobra usage/errors for runtime errors

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -50,6 +50,13 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no domains provided (use positional args or --file)")
 	}
 
+	// Past this point every error is a runtime error (not a flag/input
+	// error), so suppress Cobra's automatic usage and error output.
+	// Per-domain errors are already visible in the results; the non-zero
+	// exit code is still preserved for scripts.
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
 	// Build checker from config.
 	checker, cmdTimeout, err := buildChecker()
 	if err != nil {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -36,6 +36,11 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Past this point every error is a runtime error, so suppress
+	// Cobra's automatic usage and error output.
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
 	checker, cmdTimeout, err := buildChecker()
 	if err != nil {
 		return err


### PR DESCRIPTION
- [+] Silence usage and errors in `check` command after input validation
- [+] Silence usage and errors in `status` command after initial checks