### PR TITLE
docs(cli): update comments to use "write" instead of "stream" for results

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -81,7 +81,9 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("check failed: %w", err)
 	}
 
-	// Stream results.
+	// Write results. All checks have completed at this point;
+	// text and JSON are flushed per-result, HTML and XLSX buffer
+	// until Close().
 	hasErrors := false
 	for _, r := range results {
 		w.WriteResult(r)

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -61,7 +61,7 @@
 //
 // # Output
 //
-// Results are streamed to stdout by default, or written to a file with the
+// Results are written to stdout by default, or to a file with the
 // --output (-o) flag. Output formats are controlled by the --format flag:
 //
 //   - text (default) — tab-separated columns: domain, status, server


### PR DESCRIPTION
- [+] Expand check.go comment to clarify result writing and output buffering
- [+] Update docs.go output description to reflect "written" terminology