### PR TITLE
docs(cli): add dedicated usage examples to cobra commands

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -17,11 +17,12 @@ import (
 
 // checkCmd is the "check" subcommand.
 var checkCmd = &cobra.Command{
-	Use:   "check [domains...]",
-	Short: "Check domains for DNS blocking",
-	Long:  checkLong,
-	Args:  cobra.ArbitraryArgs,
-	RunE:  runCheck,
+	Use:     "check [domains...]",
+	Short:   "Check domains for DNS blocking",
+	Long:    checkLong,
+	Example: checkExample,
+	Args:    cobra.ArbitraryArgs,
+	RunE:    runCheck,
 }
 
 func init() {

--- a/internal/cli/magic_embed.go
+++ b/internal/cli/magic_embed.go
@@ -13,11 +13,20 @@ import _ "embed" // required for //go:embed directives below
 //go:embed usage/root_long.txt
 var rootLong string
 
+//go:embed usage/root_example.txt
+var rootExample string
+
 //go:embed usage/check_long.txt
 var checkLong string
 
+//go:embed usage/check_example.txt
+var checkExample string
+
 //go:embed usage/status_long.txt
 var statusLong string
+
+//go:embed usage/status_example.txt
+var statusExample string
 
 //go:embed usage/config_long.txt
 var configLong string
@@ -29,3 +38,4 @@ var resultHTMLTemplate string
 
 //go:embed templates/status.html
 var statusHTMLTemplate string
+

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -22,9 +22,10 @@ var configPath string
 
 // rootCmd is the base command for the nawala CLI.
 var rootCmd = &cobra.Command{
-	Use:   "nawala [domains...]",
-	Short: "Check domains against Indonesian ISP DNS filters",
-	Long:  rootLong,
+	Use:     "nawala [domains...]",
+	Short:   "Check domains against Indonesian ISP DNS filters",
+	Long:    rootLong,
+	Example: rootExample,
 	// When bare args are provided (no subcommand), delegate to check.
 	Args: cobra.ArbitraryArgs,
 	RunE: runRoot,

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -14,11 +14,12 @@ import (
 
 // statusCmd is the "status" subcommand.
 var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show DNS server health status",
-	Long:  statusLong,
-	Args:  cobra.NoArgs,
-	RunE:  runStatus,
+	Use:     "status",
+	Short:   "Show DNS server health status",
+	Long:    statusLong,
+	Example: statusExample,
+	Args:    cobra.NoArgs,
+	RunE:    runStatus,
 }
 
 func init() {

--- a/internal/cli/usage/check_example.txt
+++ b/internal/cli/usage/check_example.txt
@@ -1,0 +1,6 @@
+  nawala check google.com reddit.com github.com
+  nawala check --file domains.txt
+  nawala check --file domains.txt --format json
+  nawala check --file domains.txt --format html -o report.html
+  nawala check --file domains.txt --format xlsx -o results.xlsx
+  nawala check --config custom.yaml --file domains.txt --format json -o out.json

--- a/internal/cli/usage/check_long.txt
+++ b/internal/cli/usage/check_long.txt
@@ -9,11 +9,3 @@ treated as comments, and blank lines are ignored.
 By default, results are streamed to stdout as tab-separated text.
 Other formats available are json, html, and xlsx. Use the --format
 flag to choose a format, and --output (-o) to write results to a file.
-
-Examples:
-  nawala check google.com reddit.com github.com
-  nawala check --file domains.txt
-  nawala check --file domains.txt --format json
-  nawala check --file domains.txt --format html -o report.html
-  nawala check --file domains.txt --format xlsx -o results.xlsx
-  nawala check --config custom.yaml --file domains.txt --format json -o out.json

--- a/internal/cli/usage/root_example.txt
+++ b/internal/cli/usage/root_example.txt
@@ -1,0 +1,4 @@
+  nawala google.com reddit.com
+  nawala check --file domains.txt
+  nawala check --file domains.txt --format json -o results.json
+  nawala status --config custom.yaml

--- a/internal/cli/usage/root_long.txt
+++ b/internal/cli/usage/root_long.txt
@@ -4,14 +4,3 @@ This tool queries known Nawala and Komdigi DNS servers for each domain
 and inspects the response for blocking indicators — CNAME redirects to
 "internetpositif.id" (Nawala-style) or Extended DNS Error 15 with
 "trustpositif.komdigi.go.id" (Komdigi-style).
-
-Usage:
-  nawala [domains...]                 check domains (shorthand)
-  nawala check [domains...] [flags]   check domains (explicit)
-  nawala status [flags]               show DNS server health
-
-Examples:
-  nawala google.com reddit.com
-  nawala check --file domains.txt
-  nawala check --file domains.txt --format json -o results.json
-  nawala status --config custom.yaml

--- a/internal/cli/usage/status_example.txt
+++ b/internal/cli/usage/status_example.txt
@@ -1,0 +1,5 @@
+  nawala status
+  nawala status --config custom.yaml
+  nawala status --format json
+  nawala status --format html -o stat.html
+  nawala status --format xlsx -o health.xlsx

--- a/internal/cli/usage/status_long.txt
+++ b/internal/cli/usage/status_long.txt
@@ -5,10 +5,3 @@ and the result includes whether the server is online and the round-trip
 latency in milliseconds.
 
 Use --config to check health of custom server configurations.
-
-Examples:
-  nawala status
-  nawala status --config custom.yaml
-  nawala status --format json
-  nawala status --format html -o stat.html
-  nawala status --format xlsx -o health.xlsx


### PR DESCRIPTION
- [+] Embed example texts for root, check, and status commands
- [+] Update cobra.Command definitions to use Example fields
- [+] Add new example txt files in usage/
- [+] Remove inline examples from long descriptions