### PR TITLE
docs: add DNS-over-TLS (DoT) configuration options to READMEs

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -193,11 +193,9 @@ c := nawala.New(
     // Batasi pemeriksaan serentak hingga 50 goroutine.
     nawala.WithConcurrency(50),
 
-    // Gunakan klien DNS kustom (misalnya, untuk TCP atau DNS-over-TLS).
-    nawala.WithDNSClient(&dns.Client{
-        Timeout: 10 * time.Second,
-        Net:     "tcp-tls",
-    }),
+    // Gunakan transport DNS-over-TLS (DoT).
+    nawala.WithProtocol("tcp-tls"),
+    nawala.WithTLSServerName("dns.example.com"),
 
     // Atur ukuran EDNS0 kustom (default adalah 1232 untuk mencegah fragmentasi).
     nawala.WithEDNS0Size(4096),
@@ -214,6 +212,9 @@ c := nawala.New(
 | `WithCache(c)` | dalam-memori | Implementasi `Cache` kustom (pass `nil` untuk menonaktifkan) |
 | `WithConcurrency(n)` | `100` | Maksimum pemeriksaan DNS serentak (ukuran semaphore) |
 | `WithEDNS0Size(n)` | `1232` | Ukuran buffer UDP EDNS0 (mencegah fragmentasi) |
+| `WithProtocol(s)` | `"udp"` | Transport DNS: `"udp"`, `"tcp"`, atau `"tcp-tls"` (DoT) |
+| `WithTLSServerName(s)` | `""` | Override nama server TLS SNI (hanya tcp-tls) |
+| `WithTLSSkipVerify()` | `false` | Lewati verifikasi sertifikat TLS (hanya tcp-tls) |
 | `WithDNSClient(c)` | klien UDP | `*dns.Client` kustom untuk TCP, TLS, atau dialer kustom |
 | `WithServer(s)` | — | **Usang (Deprecated):** gunakan `Checker.SetServers`. Tambahkan atau ganti server tunggal |
 | `WithServers(s)` | Default Nawala | Ganti semua server DNS |

--- a/README.md
+++ b/README.md
@@ -196,11 +196,9 @@ c := nawala.New(
     // Limit concurrent checks to 50 goroutines.
     nawala.WithConcurrency(50),
 
-    // Use a custom DNS client (e.g., for TCP or DNS-over-TLS).
-    nawala.WithDNSClient(&dns.Client{
-        Timeout: 10 * time.Second,
-        Net:     "tcp-tls",
-    }),
+    // Use DNS-over-TLS (DoT) transport.
+    nawala.WithProtocol("tcp-tls"),
+    nawala.WithTLSServerName("dns.example.com"),
 
     // Set custom EDNS0 size (default is 1232 to prevent fragmentation).
     nawala.WithEDNS0Size(4096),
@@ -217,12 +215,16 @@ c := nawala.New(
 | `WithCache(c)` | in-memory | Custom `Cache` implementation (pass `nil` to disable) |
 | `WithConcurrency(n)` | `100` | Max concurrent DNS checks (semaphore size) |
 | `WithEDNS0Size(n)` | `1232` | EDNS0 UDP buffer size (prevents fragmentation) |
+| `WithProtocol(s)` | `"udp"` | DNS transport: `"udp"`, `"tcp"`, or `"tcp-tls"` (DoT) |
+| `WithTLSServerName(s)` | `""` | TLS SNI server name override (tcp-tls only) |
+| `WithTLSSkipVerify()` | `false` | Skip TLS certificate verification (tcp-tls only) |
 | `WithDNSClient(c)` | UDP client | Custom `*dns.Client` for TCP, TLS, or custom dialer |
 | `WithServer(s)` | — | **Deprecated:** use `Checker.SetServers`. Add or replace a single server |
 | `WithServers(s)` | Nawala defaults | Replace all DNS servers |
 | `Checker.SetServers(s)` | — | Hot-reload: Add or replace servers at runtime safely |
 | `Checker.HasServer(s)` | — | Hot-reload: Check if a server is configured at runtime safely |
 | `Checker.DeleteServers(s)` | — | Hot-reload: Remove servers at runtime safely |
+
 
 ## API
 


### PR DESCRIPTION
- [+] Update code examples to use `WithProtocol("tcp-tls")` and `WithTLSServerName`
- [+] Add table rows for `WithProtocol`, `WithTLSServerName`, and `WithTLSSkipVerify` options
- [+] Apply changes to both English (README.md) and Indonesian (README.id.md) versions