### PR TITLE
refactor(cli): move config validation before silencing errors in check and status

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -51,18 +51,18 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no domains provided (use positional args or --file)")
 	}
 
+	// Build checker from config.
+	checker, cmdTimeout, err := buildChecker()
+	if err != nil {
+		return err
+	}
+
 	// Past this point every error is a runtime error (not a flag/input
 	// error), so suppress Cobra's automatic usage and error output.
 	// Per-domain errors are already visible in the results; the non-zero
 	// exit code is still preserved for scripts.
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
-
-	// Build checker from config.
-	checker, cmdTimeout, err := buildChecker()
-	if err != nil {
-		return err
-	}
 
 	// Create output writer.
 	w, err := NewWriter(outputPath, format)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -37,15 +37,15 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Past this point every error is a runtime error, so suppress
-	// Cobra's automatic usage and error output.
-	cmd.SilenceUsage = true
-	cmd.SilenceErrors = true
-
 	checker, cmdTimeout, err := buildChecker()
 	if err != nil {
 		return err
 	}
+
+	// Past this point every error is a runtime error, so suppress
+	// Cobra's automatic usage and error output.
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
 
 	w, err := NewWriter(outputPath, format)
 	if err != nil {


### PR DESCRIPTION
- [+] Reorder check command to call buildChecker before cmd.SilenceUsage/Errors
- [+] Reorder status command to set cmd.SilenceUsage/Errors after buildChecker