### PR TITLE
fix(cli): trim trailing newlines from embedded Cobra examples cross-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ c := nawala.New(
 | `Checker.HasServer(s)` | — | Hot-reload: Check if a server is configured at runtime safely |
 | `Checker.DeleteServers(s)` | — | Hot-reload: Remove servers at runtime safely |
 
-
 ## API
 
 ### Core Methods

--- a/internal/cli/magic_embed.go
+++ b/internal/cli/magic_embed.go
@@ -5,7 +5,10 @@
 
 package cli
 
-import _ "embed" // required for //go:embed directives below
+import (
+	_ "embed" // required for //go:embed directives below
+	"strings"
+)
 
 // Embedded usage text for Cobra command Long descriptions.
 // The text files are compiled into the binary and never read from disk.
@@ -31,6 +34,17 @@ var statusExample string
 //go:embed usage/config_long.txt
 var configLong string
 
+func init() {
+	// Trim trailing newlines from embedded example strings so Cobra's
+	// help output doesn't produce double blank lines after Examples.
+	// We must set the fields directly on the command structs because
+	// package-level var initialisation copies the string value before
+	// any init() runs. The cutset includes \r for Windows CRLF endings.
+	rootCmd.Example = strings.TrimRight(rootExample, "\r\n")
+	checkCmd.Example = strings.TrimRight(checkExample, "\r\n")
+	statusCmd.Example = strings.TrimRight(statusExample, "\r\n")
+}
+
 // Embedded HTML templates for report output.
 
 //go:embed templates/result.html
@@ -38,4 +52,3 @@ var resultHTMLTemplate string
 
 //go:embed templates/status.html
 var statusHTMLTemplate string
-

--- a/internal/cli/magic_embed.go
+++ b/internal/cli/magic_embed.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-// Embedded usage text for Cobra command Long descriptions.
+// Embedded usage text for Cobra command Long descriptions and Examples.
 // The text files are compiled into the binary and never read from disk.
 
 //go:embed usage/root_long.txt
@@ -46,6 +46,7 @@ func init() {
 }
 
 // Embedded HTML templates for report output.
+// Like the usage text above, they are compiled into the binary and never read from disk.
 
 //go:embed templates/result.html
 var resultHTMLTemplate string

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -222,6 +222,38 @@ func TestMagicEmbed_VarsNotEmpty(t *testing.T) {
 	}
 }
 
+// TestMagicEmbed_ExamplesTrimmed verifies that the init() in magic_embed.go
+// correctly strips trailing newlines from embedded example strings on the
+// Cobra command structs. This is important cross-platform: Git on Windows
+// may check out files with \r\n endings.
+func TestMagicEmbed_ExamplesTrimmed(t *testing.T) {
+	tests := []struct {
+		name    string
+		example string
+	}{
+		{"rootCmd", rootCmd.Example},
+		{"checkCmd", checkCmd.Example},
+		{"statusCmd", statusCmd.Example},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Logf("%s.Example = %q", tt.name, tt.example)
+
+			if tt.example == "" {
+				t.Errorf("%s.Example is empty — embed or init failed", tt.name)
+				return
+			}
+			if strings.HasSuffix(tt.example, "\n") {
+				t.Errorf("%s.Example has trailing \\n — TrimRight did not apply", tt.name)
+			}
+			if strings.HasSuffix(tt.example, "\r") {
+				t.Errorf("%s.Example has trailing \\r — TrimRight did not apply", tt.name)
+			}
+		})
+	}
+}
+
 // newStatusCmd creates a fresh status command for isolated testing.
 func newStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{


### PR DESCRIPTION
- [+] Add init() in magic_embed.go to trim rootCmd, checkCmd, and statusCmd.Example
- [+] Add TestMagicEmbed_ExamplesTrimmed to verify trimming works
- [+] Remove extraneous blank line in README.md