### PR TITLE
refactor(cli): improve output Writer for JSON envelopes and XLSX handling

### DIFF
--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -41,6 +41,7 @@ type Writer struct {
 
 	format      string // "text", "json", "html", "xlsx"
 	jsonStarted bool   // tracks if we started the JSON array
+	jsonKey     string // "result" or "status" — set by the first JSON write
 	outputPath  string // original path (needed by XLSX SaveAs)
 
 	// Buffered results/statuses for HTML and XLSX (rendered at Close time).
@@ -51,8 +52,18 @@ type Writer struct {
 // NewWriter creates a Writer that writes to the given path.
 // If path is empty, it writes to stdout.
 // Format must be one of: "text", "json", "html", "xlsx".
+//
+// For XLSX format with a non-empty path, no file is opened here;
+// [excelize.File.SaveAs] creates the file directly at Close time.
 func NewWriter(path string, format string) (*Writer, error) {
 	w := &Writer{format: format, outputPath: path}
+
+	// XLSX with a file path: excelize.SaveAs manages file I/O directly,
+	// so we skip os.Create to avoid an unused file descriptor.
+	if format == FormatXLSX && path != "" {
+		// w.w and w.closer remain nil; closeXLSX writes via SaveAs.
+		return w, nil
+	}
 
 	if path == "" {
 		w.w = bufio.NewWriter(os.Stdout)
@@ -123,6 +134,7 @@ func (w *Writer) writeJSON(r nawala.Result) {
 	if !w.jsonStarted {
 		_, _ = w.w.WriteString(`{"nawala":{"result":[`)
 		w.jsonStarted = true
+		w.jsonKey = "result"
 	} else {
 		_, _ = w.w.WriteString(",")
 	}
@@ -182,6 +194,7 @@ func (w *Writer) writeStatusJSON(s nawala.ServerStatus) {
 	if !w.jsonStarted {
 		_, _ = w.w.WriteString(`{"nawala":{"status":[`)
 		w.jsonStarted = true
+		w.jsonKey = "status"
 	} else {
 		_, _ = w.w.WriteString(",")
 	}
@@ -356,6 +369,14 @@ func (w *Writer) Close() error {
 		if w.jsonStarted {
 			_, _ = w.w.WriteString("]}}\n")
 			w.jsonStarted = false
+		} else if w.w != nil {
+			// No results/statuses were written. Emit a valid empty envelope
+			// so consumers always receive well-formed JSON.
+			key := w.jsonKey
+			if key == "" {
+				key = "result" // default envelope for check output
+			}
+			_, _ = fmt.Fprintf(w.w, "{\"nawala\":{\"%s\":[]}}\n", key)
 		}
 	case FormatHTML:
 		if err := w.closeHTML(); err != nil {
@@ -365,11 +386,7 @@ func (w *Writer) Close() error {
 		if err := w.closeXLSX(); err != nil {
 			return err
 		}
-		// XLSX writes directly via SaveAs/WriteTo; skip bufio/tabwriter flush
-		// and go straight to closing the opener (if any).
-		if w.closer != nil {
-			return w.closer.Close()
-		}
+		// XLSX writes directly via SaveAs/WriteTo; skip bufio/tabwriter flush.
 		return nil
 	}
 

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -481,3 +481,65 @@ func TestWriter_Close_XLSX_Error(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "forced write error")
 }
+
+// --- Tests for pitfall fixes ---
+
+func TestNewWriter_XLSX_SkipsFileCreate(t *testing.T) {
+	// Pitfall #6: XLSX with a file path should NOT open an os.Create file
+	// descriptor. excelize.SaveAs manages file I/O directly.
+	path := filepath.Join(t.TempDir(), "skip_create.xlsx")
+	w, err := NewWriter(path, FormatXLSX)
+	require.NoError(t, err)
+
+	assert.Nil(t, w.w, "expected w.w to be nil for XLSX file path (no bufio.Writer)")
+	assert.Nil(t, w.closer, "expected closer to be nil for XLSX file path (no os.Create)")
+	assert.Equal(t, path, w.outputPath, "expected outputPath to be set")
+
+	// Write and close; the XLSX should still be created via SaveAs.
+	w.WriteResult(nawala.Result{Domain: "test.com", Blocked: false, Server: "8.8.8.8"})
+	require.NoError(t, w.Close())
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0), "XLSX file should be non-empty")
+}
+
+func TestWriter_Close_JSON_EmptyResults(t *testing.T) {
+	// Pitfall #8: Closing a JSON writer with zero results should emit
+	// a valid empty JSON envelope instead of an empty file.
+	w, buf := testWriter(FormatJSON)
+
+	err := w.Close()
+	require.NoError(t, err)
+
+	out := buf.String()
+	var wrapper struct {
+		Nawala struct {
+			Result []jsonResult `json:"result"`
+		} `json:"nawala"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &wrapper),
+		"expected valid JSON, got: %s", out)
+	assert.Empty(t, wrapper.Nawala.Result, "expected empty result array")
+}
+
+func TestWriter_Close_JSON_EmptyStatuses(t *testing.T) {
+	// Pitfall #8: When a JSON writer with "status" key has zero writes,
+	// Close should emit a valid empty envelope. We simulate this by
+	// setting jsonKey manually (since no WriteStatus was called).
+	w, buf := testWriter(FormatJSON)
+	w.jsonKey = "status" // simulate the intent to write statuses
+
+	err := w.Close()
+	require.NoError(t, err)
+
+	out := buf.String()
+	var wrapper struct {
+		Nawala struct {
+			Status []jsonStatus `json:"status"`
+		} `json:"nawala"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &wrapper),
+		"expected valid JSON, got: %s", out)
+	assert.Empty(t, wrapper.Nawala.Status, "expected empty status array")
+}


### PR DESCRIPTION
- [+] Add `jsonKey` field to track "result" or "status" envelope type
- [+] Skip early file creation for XLSX with path (lazy init via `SaveAs`)
- [+] Set `jsonKey` on first JSON write in `writeJSON` and `writeStatusJSON`
- [+] Emit valid empty JSON envelope in `Close()` if no writes occurred
- [+] Simplify XLSX `Close()` logic (no-op for lazy init)