### PR TITLE
fix(cli): omit blocked field from JSON output when error present

### DIFF
--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -86,9 +86,11 @@ func NewWriter(path string, format string) (*Writer, error) {
 }
 
 // jsonResult is the JSON representation of a check result.
+// Blocked is omitted when Error is set — a failed check has no meaningful block
+// state, and emitting false would be misleading to callers.
 type jsonResult struct {
 	Domain  string `json:"domain"`
-	Blocked bool   `json:"blocked"`
+	Blocked *bool  `json:"blocked,omitempty"`
 	Server  string `json:"server"`
 	Error   string `json:"error,omitempty"`
 }
@@ -123,12 +125,15 @@ func (w *Writer) writeText(r nawala.Result) {
 // writeJSON writes a check result as a JSON array element.
 func (w *Writer) writeJSON(r nawala.Result) {
 	jr := jsonResult{
-		Domain:  r.Domain,
-		Blocked: r.Blocked,
-		Server:  r.Server,
+		Domain: r.Domain,
+		Server: r.Server,
 	}
 	if r.Error != nil {
 		jr.Error = r.Error.Error()
+	} else {
+		// Only emit blocked when the check succeeded — a failed check has no
+		// meaningful block state.
+		jr.Blocked = &r.Blocked
 	}
 
 	data, _ := json.Marshal(jr)

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -124,7 +124,9 @@ func TestWriter_WriteResult_JSON(t *testing.T) {
 	jr := wrapper.Nawala.Result[0]
 
 	assert.Equal(t, "google.com", jr.Domain)
-	assert.False(t, jr.Blocked)
+	if assert.NotNil(t, jr.Blocked, "expected blocked to be present when no error") {
+		assert.False(t, *jr.Blocked)
+	}
 	assert.Empty(t, jr.Error)
 }
 
@@ -148,6 +150,8 @@ func TestWriter_WriteResult_JSONWithError(t *testing.T) {
 	jr := wrapper.Nawala.Result[0]
 
 	assert.Equal(t, "dns timeout", jr.Error)
+	// blocked must be absent from JSON when there is an error.
+	assert.Nil(t, jr.Blocked, "blocked should be omitted when error is present")
 }
 
 func TestWriter_WriteResult_JSON_MultipleResults(t *testing.T) {
@@ -166,7 +170,9 @@ func TestWriter_WriteResult_JSON_MultipleResults(t *testing.T) {
 	require.Len(t, wrapper.Nawala.Result, 2)
 	assert.Equal(t, "google.com", wrapper.Nawala.Result[0].Domain)
 	assert.Equal(t, "reddit.com", wrapper.Nawala.Result[1].Domain)
-	assert.True(t, wrapper.Nawala.Result[1].Blocked)
+	if assert.NotNil(t, wrapper.Nawala.Result[1].Blocked, "expected blocked to be present for successful result") {
+		assert.True(t, *wrapper.Nawala.Result[1].Blocked)
+	}
 }
 
 func TestWriter_WriteStatus_Text_Online(t *testing.T) {


### PR DESCRIPTION
- [+] Update jsonResult struct to use *bool for Blocked with omitempty tag
- [+] Modify writeJSON to conditionally set Blocked only on successful checks
- [+] Update tests to assert Blocked presence for success and absence for errors