### PR TITLE
feat(cli): add config version tracking and mismatch warnings

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -52,7 +52,7 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build checker from config.
-	checker, cmdTimeout, err := buildChecker()
+	checker, cmdTimeout, err := buildChecker(cmd.ErrOrStderr())
 	if err != nil {
 		return err
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -18,7 +18,14 @@ import (
 )
 
 // Config holds the CLI configuration loaded from a JSON or YAML file.
+// ConfigVersion records the version string declared in the file envelope
+// (nawala.version). It is populated by [loadConfig] and is not serialised
+// back to disk — it is a read-only metadata field used only for version
+// compatibility checks.
 type Config struct {
+	// ConfigVersion is the "version" field from the file envelope, e.g. "0.6.5".
+	// It is empty when the file omits the field.
+	ConfigVersion  string
 	Timeout        string      `json:"timeout"         yaml:"timeout"`
 	CommandTimeout string      `json:"command_timeout" yaml:"command_timeout"`
 	MaxRetries     *int        `json:"max_retries"     yaml:"max_retries"`
@@ -35,15 +42,17 @@ type Config struct {
 // configFile is the top-level envelope that wraps Config in a JSON or YAML
 // config file. The file format mirrors the JSON output envelope:
 //
-//	{"nawala":{"configuration":{...}}}
+//	{"nawala":{"version":"0.6.5","configuration":{...}}}
 //
 // Or in YAML:
 //
 //	nawala:
+//	  version: "0.6.5"
 //	  configuration:
-//	    timeout: 10s
+//	    timeout: 5s
 type configFile struct {
 	Nawala struct {
+		Version       string `json:"version"       yaml:"version"`
 		Configuration Config `json:"configuration" yaml:"configuration"`
 	} `json:"nawala" yaml:"nawala"`
 }
@@ -87,6 +96,7 @@ func loadConfig(path string) (*Config, error) {
 	}
 
 	cfg := cf.Nawala.Configuration
+	cfg.ConfigVersion = cf.Nawala.Version
 	return &cfg, nil
 }
 

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -6,11 +6,14 @@
 package cli
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/H0llyW00dzZ/nawala-checker/src/nawala"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -207,7 +210,7 @@ func TestBuildChecker_DisableCacheNoCache(t *testing.T) {
 	configPath = path
 	defer func() { configPath = saved }()
 
-	checker, _, err := buildChecker()
+	checker, _, err := buildChecker(io.Discard)
 	require.NoError(t, err)
 	require.NotNil(t, checker)
 
@@ -291,7 +294,7 @@ func TestBuildChecker_CustomCommandTimeout(t *testing.T) {
 	configPath = path
 	defer func() { configPath = saved }()
 
-	_, cmdTimeout, err := buildChecker()
+	_, cmdTimeout, err := buildChecker(io.Discard)
 	require.NoError(t, err)
 	assert.Equal(t, 2*time.Minute, cmdTimeout)
 }
@@ -305,6 +308,66 @@ func TestBuildChecker_InvalidCommandTimeout(t *testing.T) {
 	configPath = path
 	defer func() { configPath = saved }()
 
-	_, _, err := buildChecker()
+	_, _, err := buildChecker(io.Discard)
 	assert.Error(t, err, "expected error for invalid command_timeout")
+}
+
+// TestLoadConfig_CapturesVersion verifies that loadConfig populates
+// Config.ConfigVersion from the nawala.version envelope field.
+func TestLoadConfig_CapturesVersion(t *testing.T) {
+	t.Run("JSON with version", func(t *testing.T) {
+		content := `{"nawala":{"version":"1.2.3","configuration":{"timeout":"5s"}}}`
+		path := filepath.Join(t.TempDir(), "config.json")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+		cfg, err := loadConfig(path)
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.3", cfg.ConfigVersion)
+		assert.Equal(t, "5s", cfg.Timeout)
+	})
+
+	t.Run("YAML with version", func(t *testing.T) {
+		content := "nawala:\n  version: \"2.0.0\"\n  configuration:\n    timeout: 10s\n"
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+		cfg, err := loadConfig(path)
+		require.NoError(t, err)
+		assert.Equal(t, "2.0.0", cfg.ConfigVersion)
+	})
+
+	t.Run("no version field", func(t *testing.T) {
+		content := `{"nawala":{"configuration":{"timeout":"5s"}}}`
+		path := filepath.Join(t.TempDir(), "no_version.json")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+		cfg, err := loadConfig(path)
+		require.NoError(t, err)
+		assert.Empty(t, cfg.ConfigVersion, "omitted version should leave ConfigVersion empty")
+	})
+}
+
+// TestWarnConfigVersion covers all three branches of warnConfigVersion:
+// empty (skip), matching (skip), and mismatched (print warning to writer).
+func TestWarnConfigVersion(t *testing.T) {
+	t.Run("empty version - no warning", func(t *testing.T) {
+		var buf bytes.Buffer
+		warnConfigVersion(&buf, &Config{ConfigVersion: ""})
+		assert.Empty(t, buf.String(), "empty ConfigVersion must not produce output")
+	})
+
+	t.Run("matching version - no warning", func(t *testing.T) {
+		var buf bytes.Buffer
+		warnConfigVersion(&buf, &Config{ConfigVersion: nawala.Version})
+		assert.Empty(t, buf.String(), "matching version must not produce output")
+	})
+
+	t.Run("mismatched version - prints warning", func(t *testing.T) {
+		var buf bytes.Buffer
+		warnConfigVersion(&buf, &Config{ConfigVersion: "0.0.1"})
+		out := buf.String()
+		assert.Contains(t, out, "warning")
+		assert.Contains(t, out, "0.0.1")
+		assert.Contains(t, out, "nawala config")
+	})
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/H0llyW00dzZ/nawala-checker/src/nawala"
@@ -66,7 +67,9 @@ func Execute() error { return rootCmd.Execute() }
 // buildChecker creates a nawala.Checker from the config file (if provided)
 // and resolves the command timeout. The returned duration is the overall
 // timeout for the CLI command; it defaults to defaultCommandTimeout.
-func buildChecker() (*nawala.Checker, time.Duration, error) {
+// errw receives any diagnostic warnings (e.g. config version mismatch);
+// callers should pass cmd.ErrOrStderr() so output respects Cobra's writer.
+func buildChecker(errw io.Writer) (*nawala.Checker, time.Duration, error) {
 	if configPath == "" {
 		return nawala.New(), defaultCommandTimeout, nil
 	}
@@ -75,6 +78,8 @@ func buildChecker() (*nawala.Checker, time.Duration, error) {
 	if err != nil {
 		return nil, 0, err
 	}
+
+	warnConfigVersion(errw, cfg)
 
 	opts, err := cfg.toOptions()
 	if err != nil {
@@ -90,4 +95,24 @@ func buildChecker() (*nawala.Checker, time.Duration, error) {
 	}
 
 	return nawala.New(opts...), cmdTimeout, nil
+}
+
+// warnConfigVersion prints a warning to errw when the version declared in
+// the config file does not match the running CLI version. The config is still
+// applied; this is purely informational so the user knows to regenerate it.
+//
+// The warning is silently skipped when the file omits the version field
+// (ConfigVersion is empty), preserving backwards compatibility with configs
+// that predate the versioned envelope format.
+func warnConfigVersion(errw io.Writer, cfg *Config) {
+	if cfg.ConfigVersion == "" || cfg.ConfigVersion == nawala.Version {
+		return
+	}
+	_, _ = fmt.Fprintf(
+		errw,
+		"nawala: warning: config version %q does not match CLI version %q — "+
+			"some settings may not work as expected; run \"nawala config\" to regenerate\n",
+		cfg.ConfigVersion,
+		nawala.Version,
+	)
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -8,6 +8,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,7 +22,7 @@ func TestBuildChecker_NoConfig(t *testing.T) {
 	configPath = ""
 	defer func() { configPath = saved }()
 
-	c, cmdTimeout, err := buildChecker()
+	c, cmdTimeout, err := buildChecker(io.Discard)
 	if err != nil {
 		t.Fatalf("buildChecker() error: %v", err)
 	}
@@ -44,7 +45,7 @@ func TestBuildChecker_WithConfig(t *testing.T) {
 	configPath = path
 	defer func() { configPath = saved }()
 
-	c, cmdTimeout, err := buildChecker()
+	c, cmdTimeout, err := buildChecker(io.Discard)
 	if err != nil {
 		t.Fatalf("buildChecker() error: %v", err)
 	}
@@ -66,7 +67,7 @@ func TestBuildChecker_InvalidConfig(t *testing.T) {
 	configPath = path
 	defer func() { configPath = saved }()
 
-	_, _, err := buildChecker()
+	_, _, err := buildChecker(io.Discard)
 	if err == nil {
 		t.Fatal("expected error for invalid config, got nil")
 	}
@@ -83,7 +84,7 @@ func TestBuildChecker_InvalidDuration(t *testing.T) {
 	configPath = path
 	defer func() { configPath = saved }()
 
-	_, _, err := buildChecker()
+	_, _, err := buildChecker(io.Discard)
 	if err == nil {
 		t.Fatal("expected error for invalid timeout, got nil")
 	}
@@ -94,7 +95,7 @@ func TestBuildChecker_MissingFile(t *testing.T) {
 	configPath = "/nonexistent/config.json"
 	defer func() { configPath = saved }()
 
-	_, _, err := buildChecker()
+	_, _, err := buildChecker(io.Discard)
 	if err == nil {
 		t.Fatal("expected error for missing config, got nil")
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -37,7 +37,7 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	checker, cmdTimeout, err := buildChecker()
+	checker, cmdTimeout, err := buildChecker(cmd.ErrOrStderr())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- [+] Add ConfigVersion field to Config and populate from file envelope
- [+] Introduce warnConfigVersion to print warnings on version mismatch
- [+] Refactor buildChecker to accept io.Writer for diagnostics
- [+] Update check.go and status.go to pass cmd.ErrOrStderr()
- [+] Update all tests to pass io.Discard and add version handling tests