### PR TITLE
docs(readme): update configuration examples and add notes on new features

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -87,18 +87,26 @@ nawala status
 nawala --version
 ```
 
+> [!NOTE]
+> Input domain bersifat **case-insensitive** — `Google.com` dan `google.com` dianggap sebagai
+> domain yang sama dan akan dideduplikasi sebelum diperiksa. Domain Unicode (IDN) secara
+> **otomatis dikonversi** ke Punycode (ACE) menggunakan profil IDNA Lookup (UTS\#46), sehingga
+> Anda dapat memasukkan `例え.jp` langsung dan akan diperiksa sebagai `xn--r8jz45g.jp`.
+
 Contoh file konfigurasi (`config.json`) — format nawala envelope:
 
 ```json
 {
   "nawala": {
+    "version": "0.6.5",
     "configuration": {
-      "timeout": "10s",
+      "timeout": "5s",
       "command_timeout": "30s",
-      "max_retries": 3,
-      "cache_ttl": "10m",
+      "max_retries": 2,
+      "cache_ttl": "5m",
       "disable_cache": false,
-      "concurrency": 50,
+      "concurrency": 100,
+      "edns0_size": 1232,
       "protocol": "udp",
       "tls_server_name": "",
       "tls_skip_verify": false,
@@ -112,8 +120,15 @@ Contoh file konfigurasi (`config.json`) — format nawala envelope:
 ```
 
 > [!NOTE]
+> Field `version` mencatat versi CLI yang menghasilkan konfigurasi. Jika tidak cocok dengan
+> CLI yang berjalan, peringatan akan dicetak ke stderr dan konfigurasi tetap diterapkan.
+> Buat ulang dengan `nawala config --json -o config.json` untuk memperbaruinya.
+>
 > Atur `disable_cache: true` untuk menonaktifkan cache dalam memori bawaan sepenuhnya.
 > Jika diaktifkan, nilai `cache_ttl` tidak berpengaruh.
+>
+> Atur `edns0_size` untuk mengontrol ukuran buffer UDP EDNS0 (default `1232`, atur ke `4096`
+> untuk resolver yang mendukung payload yang lebih besar).
 >
 > Atur `protocol` ke `"udp"` (default), `"tcp"`, atau `"tcp-tls"` (DNS over TLS / DoT)
 > untuk memilih transport DNS. Timeout dan ukuran EDNS0 tetap berlaku di semua protokol.

--- a/README.md
+++ b/README.md
@@ -87,18 +87,26 @@ nawala status
 nawala --version
 ```
 
+> [!NOTE]
+> Domain input is **case-insensitive** — `Google.com` and `google.com` are treated as the same
+> domain and deduplicated before checking. Unicode (IDN) domains are **automatically converted**
+> to Punycode (ACE) using the IDNA Lookup profile (UTS\#46), so you can pass `例え.jp` directly
+> and it will be checked as `xn--r8jz45g.jp`.
+
 Configuration file example (`config.json`) — nawala envelope format:
 
 ```json
 {
   "nawala": {
+    "version": "0.6.5",
     "configuration": {
-      "timeout": "10s",
+      "timeout": "5s",
       "command_timeout": "30s",
-      "max_retries": 3,
-      "cache_ttl": "10m",
+      "max_retries": 2,
+      "cache_ttl": "5m",
       "disable_cache": false,
-      "concurrency": 50,
+      "concurrency": 100,
+      "edns0_size": 1232,
       "protocol": "udp",
       "tls_server_name": "",
       "tls_skip_verify": false,
@@ -112,8 +120,15 @@ Configuration file example (`config.json`) — nawala envelope format:
 ```
 
 > [!NOTE]
+> The `version` field records which CLI version generated the config. If it does not match
+> the running CLI, a warning is printed to stderr and the config is still applied. Regenerate
+> with `nawala config --json -o config.json` to update it.
+>
 > Set `disable_cache: true` to disable the built-in in-memory cache entirely.
 > When set, `cache_ttl` has no effect.
+>
+> Set `edns0_size` to control the EDNS0 UDP buffer size (default `1232`, set to `4096` for
+> resolvers that support larger payloads).
 >
 > Set `protocol` to `"udp"` (default), `"tcp"`, or `"tcp-tls"` (DNS over TLS / DoT)
 > to select the DNS transport. Timeout and EDNS0 size compose correctly with all protocols.


### PR DESCRIPTION
- [+] Add note on case-insensitive domains and automatic IDN Punycode conversion
- [+] Update config.json example with version field, new defaults (timeout 5s, max_retries 2, cache_ttl 5m, concurrency 100), and edns0_size
- [+] Add notes explaining version field usage and edns0_size control