### PR TITLE
Update [CI/CD] 🧪 Vet & Test Coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,9 @@ jobs:
         go-version:
           - '1.25.6'
           - '1.25.7'
+          - '1.25.8'
           - '1.26.0'
+          - '1.26.1'
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
- [+] ci(test): add Go 1.25.8 and 1.26.1 to test matrix