### PR TITLE
Update Documentation

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -163,7 +163,7 @@ Contoh file konfigurasi (`config.json`) — format nawala envelope:
 > `keep_alive_pool_size` — mengaktifkan pooling koneksi TCP/TLS persisten bila diisi dengan nilai positif
 > bersama `protocol: tcp` atau `protocol: tcp-tls`. Nilai `0` (default) menonaktifkan pool;
 > jika field tidak ada di config file, nilainya nil dan **tidak mempengaruhi** penggunaan tcp/tcp-tls yang sudah ada.
-> Memerlukan server yang mendukung RFC 7766 (tcp) atau RFC 7858 (tcp-tls) — gunakan dengan penyedia DoT
+> Memerlukan server yang mendukung [RFC 7766](https://www.rfc-editor.org/rfc/rfc7766.html) (tcp) atau [RFC 7858](https://www.rfc-editor.org/rfc/rfc7858.html) (tcp-tls) — gunakan dengan penyedia DoT
 > (contoh: Cloudflare `1.1.1.1:853`, Google `8.8.8.8:853`) atau resolver lokal modern.
 > Server ISP Nawala bawaan tidak mendapat manfaat dari fitur ini.
 
@@ -282,7 +282,7 @@ c := nawala.New(
 | `Checker.SetServers(s)` | — | Hot-reload: Tambahkan atau ganti server saat runtime (aman untuk konkurensi) |
 | `Checker.HasServer(s)` | — | Hot-reload: Periksa apakah server dikonfigurasi saat runtime (aman untuk konkurensi) |
 | `Checker.DeleteServers(s)` | — | Hot-reload: Hapus server saat runtime (aman untuk konkurensi) |
-| `WithKeepAlive(n)` | dinonaktifkan | Pool koneksi TCP/TLS persisten; `n` = maks koneksi idle per server (≤0 → `min(concurrency,10)`); **memerlukan dukungan server RFC 7766 (tcp) atau RFC 7858 (tcp-tls)** — gunakan dengan penyedia DoT atau resolver kustom modern, bukan server ISP Nawala bawaan; diabaikan untuk UDP |
+| `WithKeepAlive(n)` | dinonaktifkan | Pool koneksi TCP/TLS persisten; `n` = maks koneksi idle per server (≤0 → `min(concurrency,10)`); **memerlukan dukungan server [RFC 7766](https://www.rfc-editor.org/rfc/rfc7766.html) (tcp) atau [RFC 7858](https://www.rfc-editor.org/rfc/rfc7858.html) (tcp-tls)** — gunakan dengan penyedia DoT atau resolver kustom modern, bukan server ISP Nawala bawaan; diabaikan untuk UDP |
 
 ## 🔌 API
 

--- a/README.id.md
+++ b/README.id.md
@@ -34,6 +34,8 @@ SDK Go untuk memeriksa apakah domain diblokir oleh filter DNS ISP Indonesia (Naw
 - **Sadar konteks** — dukungan penuh untuk timeout dan pembatalan melalui `context.Context`
 - **Validasi domain** — normalisasi dan validasi nama domain otomatis
 - **Error yang diketik** — error sentinel untuk pencocokan `errors.Is` (lihat [Error](#error))
+- **Pooling koneksi** — gunakan kembali koneksi TCP/TLS yang sudah terbentuk via `WithKeepAlive` untuk menghilangkan overhead handshake
+- **Hot-reload runtime** — tambah, ganti, atau hapus server DNS dengan aman secara serentak tanpa perlu diulang (restart)
 
 ## 🚀 Performa
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ A Go SDK for checking whether domains are blocked by Indonesian ISP DNS filters 
 - **Context-aware** — full support for timeouts and cancellation via `context.Context`
 - **Domain validation** — automatic normalization and validation of domain names
 - **Typed errors** — sentinel errors for `errors.Is` matching (see [Errors](#errors))
+- **Connection pooling** — reuse established TCP/TLS connections via `WithKeepAlive` to eliminate handshake overhead
+- **Runtime hot-reload** — safely add, replace, or remove DNS servers concurrently without restarting
 
 ## 🚀 Performance
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Configuration file example (`config.json`) — nawala envelope format:
 > `keep_alive_pool_size` — enables persistent TCP/TLS connection pooling when set to a positive
 > integer alongside `protocol: tcp` or `protocol: tcp-tls`. `0` (default) disables the pool;
 > omitting the field entirely is equivalent to `0` and does **not** affect existing tcp/tcp-tls
-> usage. Requires a server supporting RFC 7766 (tcp) or RFC 7858 (tcp-tls) — use with DoT
+> usage. Requires a server supporting [RFC 7766](https://www.rfc-editor.org/rfc/rfc7766.html) (tcp) or [RFC 7858](https://www.rfc-editor.org/rfc/rfc7858.html) (tcp-tls) — use with DoT
 > providers (e.g. Cloudflare `1.1.1.1:853`, Google `8.8.8.8:853`) or modern local resolvers.
 > The default Nawala ISP servers do not benefit.
 
@@ -285,7 +285,7 @@ c := nawala.New(
 | `Checker.SetServers(s)` | — | Hot-reload: Add or replace servers at runtime safely |
 | `Checker.HasServer(s)` | — | Hot-reload: Check if a server is configured at runtime safely |
 | `Checker.DeleteServers(s)` | — | Hot-reload: Remove servers at runtime safely |
-| `WithKeepAlive(n)` | disabled | Persistent TCP/TLS conn pool; `n` = max idle conns per server (≤0 → `min(concurrency,10)`); **requires RFC 7766 (tcp) or RFC 7858 (tcp-tls) server support** — use with DoT providers or modern custom resolvers, not the default Nawala ISP servers; no-op for UDP |
+| `WithKeepAlive(n)` | disabled | Persistent TCP/TLS conn pool; `n` = max idle conns per server (≤0 → `min(concurrency,10)`); **requires [RFC 7766](https://www.rfc-editor.org/rfc/rfc7766.html) (tcp) or [RFC 7858](https://www.rfc-editor.org/rfc/rfc7858.html) (tcp-tls) server support** — use with DoT providers or modern custom resolvers, not the default Nawala ISP servers; no-op for UDP |
 
 ## 🔌 API
 

--- a/cmd/nawala/docs.go
+++ b/cmd/nawala/docs.go
@@ -96,7 +96,7 @@
 // keep_alive_pool_size enables persistent TCP/TLS connection pooling.
 // A value of 0 (default) means disabled; set to a positive integer together
 // with protocol "tcp" or "tcp-tls" to reuse connections across queries.
-// Requires a server that supports RFC 7766 (tcp) or RFC 7858 (tcp-tls) —
+// Requires a server that supports [RFC 7766] (tcp) or [RFC 7858] (tcp-tls) —
 // best used with DoT providers (e.g. Cloudflare :853, Google :853) or modern
 // local resolvers. The default Nawala/ISP servers are UDP-optimised and do not
 // benefit from this option.
@@ -106,4 +106,7 @@
 //	0   all checks completed successfully
 //	1   one or more checks encountered errors
 //	2   fatal error (invalid config, missing domains, etc.)
+//
+// [RFC 7766]: https://www.rfc-editor.org/rfc/rfc7766.html
+// [RFC 7858]: https://www.rfc-editor.org/rfc/rfc7858.html
 package main

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -227,6 +227,9 @@ func (c *Config) parseTLSSkipVerify() (nawala.Option, error) {
 // default (min(concurrency, 10)). Nil means keep-alive is disabled entirely.
 // Only effective when protocol is "tcp" or "tcp-tls" and the DNS server
 // supports [RFC 7766] / [RFC 7858] persistent connections.
+//
+// [RFC 7766]: https://www.rfc-editor.org/rfc/rfc7766.html
+// [RFC 7858]: https://www.rfc-editor.org/rfc/rfc7858.html
 func (c *Config) parseKeepAlive() (nawala.Option, error) {
 	if c.KeepAlivePoolSize == nil {
 		return nil, nil
@@ -263,6 +266,3 @@ func (c *Config) parseServers() (nawala.Option, error) {
 	}
 	return nawala.WithServers(servers), nil
 }
-
-// [RFC 7766]: https://www.rfc-editor.org/rfc/rfc7766.html
-// [RFC 7858]: https://www.rfc-editor.org/rfc/rfc7858.html

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -38,7 +38,10 @@ type Config struct {
 	TLSSkipVerify  *bool   `json:"tls_skip_verify" yaml:"tls_skip_verify"`
 	// KeepAlivePoolSize enables TCP/TLS keep-alive when non-nil and > 0.
 	// Only effective when Protocol is "tcp" or "tcp-tls" and the upstream
-	// DNS server supports RFC 7766 / RFC 7858 persistent connections.
+	// DNS server supports [RFC 7766] / [RFC 7858] persistent connections.
+	//
+	// [RFC 7766]: https://www.rfc-editor.org/rfc/rfc7766.html
+	// [RFC 7858]: https://www.rfc-editor.org/rfc/rfc7858.html
 	KeepAlivePoolSize *int        `json:"keep_alive_pool_size" yaml:"keep_alive_pool_size"`
 	Servers           []ServerDef `json:"servers"              yaml:"servers"`
 }
@@ -223,7 +226,7 @@ func (c *Config) parseTLSSkipVerify() (nawala.Option, error) {
 // A value of 0 is still passed to WithKeepAlive so the SDK can apply its own
 // default (min(concurrency, 10)). Nil means keep-alive is disabled entirely.
 // Only effective when protocol is "tcp" or "tcp-tls" and the DNS server
-// supports RFC 7766 / RFC 7858 persistent connections.
+// supports [RFC 7766] / [RFC 7858] persistent connections.
 func (c *Config) parseKeepAlive() (nawala.Option, error) {
 	if c.KeepAlivePoolSize == nil {
 		return nil, nil
@@ -260,3 +263,6 @@ func (c *Config) parseServers() (nawala.Option, error) {
 	}
 	return nawala.WithServers(servers), nil
 }
+
+// [RFC 7766]: https://www.rfc-editor.org/rfc/rfc7766.html
+// [RFC 7858]: https://www.rfc-editor.org/rfc/rfc7858.html

--- a/internal/cli/docs.go
+++ b/internal/cli/docs.go
@@ -57,7 +57,7 @@
 // Set to a positive integer together with protocol "tcp" or "tcp-tls" to avoid
 // per-query handshake overhead. 0 (default) disables the pool entirely — absent
 // from the config file means nil, so existing tcp/tcp-tls usage is unaffected.
-// Requires RFC 7766 (tcp) or RFC 7858 (tcp-tls) server support; the default
+// Requires [RFC 7766] (tcp) or [RFC 7858] (tcp-tls) server support; the default
 // Nawala ISP servers are UDP-optimised and will not benefit.
 //
 // # Domain Input
@@ -85,4 +85,6 @@
 // See [magic_embed.go] for the embed directives.
 //
 // [magic_embed.go]: https://github.com/H0llyW00dzZ/nawala-checker/blob/master/internal/cli/magic_embed.go
+// [RFC 7766]: https://www.rfc-editor.org/rfc/rfc7766.html
+// [RFC 7858]: https://www.rfc-editor.org/rfc/rfc7858.html
 package cli

--- a/src/nawala/docs.go
+++ b/src/nawala/docs.go
@@ -72,6 +72,8 @@
 //   - Typed errors — sentinel errors for [errors.Is] matching
 //   - Keep-alive connection pool — optional [WithKeepAlive] option for
 //     persistent TCP/TLS connections, avoiding per-query handshake overhead
+//   - Runtime hot-reload — safely add, replace, or remove DNS servers
+//     concurrently without restarting
 //
 // # Quick Start
 //

--- a/src/nawala/docs.go
+++ b/src/nawala/docs.go
@@ -167,7 +167,7 @@
 //   - [Checker.HasServer]     — Hot-reload: Check if a server is configured at runtime safely
 //   - [Checker.DeleteServers] — Hot-reload: Remove servers at runtime safely
 //   - [WithKeepAlive]         — Persistent TCP/TLS conn pool (idle conns per server);
-//     no-op for UDP; requires RFC 7766 (tcp) or RFC 7858 (tcp-tls) server support —
+//     no-op for UDP; requires [RFC 7766] (tcp) or [RFC 7858] (tcp-tls) server support —
 //     use with DoT providers or modern custom resolvers, NOT the default Nawala
 //     ISP servers (UDP-optimised, close TCP after each query); call [Checker.Close] when done
 //
@@ -352,4 +352,6 @@
 // [examples/]: https://github.com/H0llyW00dzZ/nawala-checker/blob/master/examples
 // [k8s]: https://kubernetes.io
 // [idiomatic Go]: https://go.dev/doc/effective_go
+// [RFC 7766]: https://www.rfc-editor.org/rfc/rfc7766.html
+// [RFC 7858]: https://www.rfc-editor.org/rfc/rfc7858.html
 package nawala

--- a/src/nawala/option.go
+++ b/src/nawala/option.go
@@ -302,28 +302,28 @@ func WithDigests(hash func(data string) string) Option {
 // # Server compatibility
 //
 // Not all DNS servers support persistent (keep-alive) TCP connections.
-// The original RFC 1035 specified that DNS/TCP connections should be
-// closed after each query-response pair. RFC 7766 (2016) later introduced
+// The original [RFC 1035] specified that DNS/TCP connections should be
+// closed after each query-response pair. [RFC 7766] (2016) later introduced
 // persistent connections as a SHOULD-level requirement for modern
-// implementations, and RFC 7858 (DNS-over-TLS) requires connection reuse.
+// implementations, and [RFC 7858] (DNS-over-TLS) requires connection reuse.
 //
 // In practice:
 //
 //   - DNS-over-TLS (tcp-tls) — strongly recommended; all major DoT
 //     providers (Cloudflare 1.1.1.1:853, Google 8.8.8.8:853, etc.) and
-//     modern resolvers fully support RFC 7858 reuse.
+//     modern resolvers fully support [RFC 7858] reuse.
 //   - Custom / local resolvers (Unbound, BIND 9.x, Knot DNS, PowerDNS) —
-//     supported; these implement RFC 7766 persistent connections.
+//     supported; these implement [RFC 7766] persistent connections.
 //   - Legacy or ISP-managed DNS servers — may not support persistent
 //     connections and close TCP after each response. The pool handles this
 //     transparently (EOF → automatic redial), so queries never fail, but
 //     there is no connection-reuse benefit.
 //
 // The default Nawala/Komdigi ISP servers are optimised for high-volume UDP
-// traffic and are not expected to keep TCP connections open. WithKeepAlive
+// traffic and are not expected to keep TCP connections open. [WithKeepAlive]
 // with those servers provides no performance benefit; it is designed for
-// custom deployments using a modern resolver that supports RFC 7766 or
-// RFC 7858.
+// custom deployments using a modern resolver that supports [RFC 7766] or
+// [RFC 7858].
 //
 // When keep-alive is enabled, call [Checker.Close] when the checker is no
 // longer needed to release idle connections:
@@ -333,6 +333,10 @@ func WithDigests(hash func(data string) string) Option {
 //	    nawala.WithKeepAlive(5),
 //	)
 //	defer c.Close()
+//
+// [RFC 1035]: https://www.rfc-editor.org/rfc/rfc1035.html
+// [RFC 7766]: https://www.rfc-editor.org/rfc/rfc7766.html
+// [RFC 7858]: https://www.rfc-editor.org/rfc/rfc7858.html
 func WithKeepAlive(poolSize int) Option {
 	return func(c *Checker) {
 		c.keepAlive = true


### PR DESCRIPTION
- [+] Update README.md and README.id.md with links to RFC 7766/7858
- [+] Enhance cmd/nawala/docs.go with RFC link references and definitions
- [+] Add RFC 7766/7858 links and definitions in internal/cli/config.go and docs.go
- [+] Update src/nawala/docs.go with RFC link for WithKeepAlive
- [+] Introduce comprehensive RFC 1035/7766/7858 links and explanations in src/nawala/option.go