### PR TITLE
refactor(cli): standardize error handling and suppress usage output

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -102,12 +102,14 @@ func runCheck(cmd *cobra.Command, args []string) error {
 
 	// Check for streaming errors (e.g., file not found, no domains)
 	if err := <-streamErrCh; err != nil {
+		w.Cancel()
 		fmt.Fprintln(cmd.ErrOrStderr(), "Error:", err)
 		return err
 	}
 
 	// Check for checker errors
 	if err := <-checkErrCh; err != nil {
+		w.Cancel()
 		err = fmt.Errorf("check failed: %w", err)
 		fmt.Fprintln(cmd.ErrOrStderr(), "Error:", err)
 		return err

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -20,12 +20,13 @@ import (
 
 // checkCmd is the "check" subcommand.
 var checkCmd = &cobra.Command{
-	Use:     "check [domains...]",
-	Short:   "Check domains for DNS blocking",
-	Long:    checkLong,
-	Example: checkExample,
-	Args:    cobra.ArbitraryArgs,
-	RunE:    runCheck,
+	Use:          "check [domains...]",
+	Short:        "Check domains for DNS blocking",
+	Long:         checkLong,
+	Example:      checkExample,
+	Args:         cobra.ArbitraryArgs,
+	RunE:         runCheck,
+	SilenceUsage: true,
 }
 
 func init() {
@@ -37,6 +38,10 @@ func init() {
 // runCheck is the shared implementation for both the root default action
 // and the explicit "check" subcommand.
 func runCheck(cmd *cobra.Command, args []string) error {
+	// Suppress Cobra's automatic usage output for any error returned from RunE.
+	// Usage is only helpful for errors caught before RunE (e.g. unknown flags).
+	cmd.SilenceUsage = true
+
 	filePath, _ := cmd.Flags().GetString("file")
 	outputPath, _ := cmd.Flags().GetString("output")
 
@@ -51,13 +56,6 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer func() { _ = checker.Close() }()
-
-	// Past this point every error is a runtime error (not a flag/input
-	// error), so suppress Cobra's automatic usage and error output.
-	// Per-domain errors are already visible in the results; the non-zero
-	// exit code is still preserved for scripts.
-	cmd.SilenceUsage = true
-	cmd.SilenceErrors = true
 
 	// Create output writer.
 	w, err := NewWriter(outputPath, format)
@@ -97,14 +95,22 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Past this point every error is a runtime error.
+	// We print runtime errors to stderr ourselves so they are always visible.
+	// The non-zero exit code is still preserved for scripts.
+	cmd.SilenceErrors = true
+
 	// Check for streaming errors (e.g., file not found, no domains)
 	if err := <-streamErrCh; err != nil {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Error:", err)
 		return err
 	}
 
 	// Check for checker errors
 	if err := <-checkErrCh; err != nil {
-		return fmt.Errorf("check failed: %w", err)
+		err = fmt.Errorf("check failed: %w", err)
+		fmt.Fprintln(cmd.ErrOrStderr(), "Error:", err)
+		return err
 	}
 
 	if hasErrors {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -17,11 +17,12 @@ import (
 
 // configCmd is the "config" subcommand.
 var configCmd = &cobra.Command{
-	Use:   "config",
-	Short: "Print the effective configuration",
-	Long:  configLong,
-	Args:  cobra.NoArgs,
-	RunE:  runConfig,
+	Use:          "config",
+	Short:        "Print the effective configuration",
+	Long:         configLong,
+	Args:         cobra.NoArgs,
+	RunE:         runConfig,
+	SilenceUsage: true,
 }
 
 func init() {
@@ -119,6 +120,10 @@ func resolveEffectiveConfig(cfg *Config) effectiveConfig {
 
 // runConfig resolves the effective configuration and writes it to stdout or a file.
 func runConfig(cmd *cobra.Command, _ []string) error {
+	// Suppress Cobra's automatic usage output for any error returned from RunE.
+	// Usage is only helpful for errors caught before RunE (e.g. unknown flags).
+	cmd.SilenceUsage = true
+
 	outputPath, _ := cmd.Flags().GetString("output")
 	jsonMode, _ := cmd.Flags().GetBool("json")
 

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -41,6 +41,7 @@ type Writer struct {
 	jsonStarted bool   // tracks if we started the JSON array
 	jsonKey     string // "result" or "status" — set by the first JSON write
 	outputPath  string // original path (needed by XLSX SaveAs)
+	cancelled   bool   // when true, Close() skips all output
 
 	// Buffered results/statuses for text, HTML and XLSX (rendered at Close time).
 	results  []nawala.Result
@@ -506,8 +507,20 @@ func (w *Writer) writeTextStatuses() {
 	}
 }
 
+// Cancel marks the writer as aborted. A subsequent Close call will skip
+// flushing any output and only release resources (e.g. close the file).
+// Call this before returning an error to prevent partial or empty output
+// from being written to stdout or the output file.
+func (w *Writer) Cancel() { w.cancelled = true }
+
 // Close flushes any buffered data, writes JSON caps, and closes the file.
 func (w *Writer) Close() error {
+	if w.cancelled {
+		if w.closer != nil {
+			return w.closer.Close()
+		}
+		return nil
+	}
 	switch w.format {
 	case FormatJSON:
 		if w.jsonStarted {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,6 +30,9 @@ var rootCmd = &cobra.Command{
 	// When bare args are provided (no subcommand), delegate to check.
 	Args: cobra.ArbitraryArgs,
 	RunE: runRoot,
+	// Suppress usage output for any error from RunE or unknown flags on root.
+	// Subcommands manage their own SilenceUsage independently.
+	SilenceUsage: true,
 }
 
 // runRoot is the root command handler. It prints the version when

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -14,12 +14,13 @@ import (
 
 // statusCmd is the "status" subcommand.
 var statusCmd = &cobra.Command{
-	Use:     "status",
-	Short:   "Show DNS server health status",
-	Long:    statusLong,
-	Example: statusExample,
-	Args:    cobra.NoArgs,
-	RunE:    runStatus,
+	Use:          "status",
+	Short:        "Show DNS server health status",
+	Long:         statusLong,
+	Example:      statusExample,
+	Args:         cobra.NoArgs,
+	RunE:         runStatus,
+	SilenceUsage: true,
 }
 
 func init() {
@@ -30,6 +31,10 @@ func init() {
 // runStatus queries all configured DNS servers for health and latency,
 // then writes the results to the configured output.
 func runStatus(cmd *cobra.Command, _ []string) error {
+	// Suppress Cobra's automatic usage output for any error returned from RunE.
+	// Usage is only helpful for errors caught before RunE (e.g. unknown flags).
+	cmd.SilenceUsage = true
+
 	outputPath, _ := cmd.Flags().GetString("output")
 
 	format, err := resolveFormat(cmd)
@@ -43,11 +48,6 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	}
 	defer func() { _ = checker.Close() }()
 
-	// Past this point every error is a runtime error, so suppress
-	// Cobra's automatic usage and error output.
-	cmd.SilenceUsage = true
-	cmd.SilenceErrors = true
-
 	w, err := NewWriter(outputPath, format)
 	if err != nil {
 		return err
@@ -60,8 +60,16 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	defer cancel()
 
 	statuses, err := checker.DNSStatus(ctx)
+
+	// Past this point every error is a runtime error.
+	// We print runtime errors to stderr ourselves so they are always visible.
+	// The non-zero exit code is still preserved for scripts.
+	cmd.SilenceErrors = true
+
 	if err != nil {
-		return fmt.Errorf("dns status check failed: %w", err)
+		err = fmt.Errorf("dns status check failed: %w", err)
+		fmt.Fprintln(cmd.ErrOrStderr(), "Error:", err)
+		return err
 	}
 	for _, s := range statuses {
 		w.WriteStatus(s)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -67,6 +67,7 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	cmd.SilenceErrors = true
 
 	if err != nil {
+		w.Cancel()
 		err = fmt.Errorf("dns status check failed: %w", err)
 		fmt.Fprintln(cmd.ErrOrStderr(), "Error:", err)
 		return err


### PR DESCRIPTION
- [+] Add SilenceUsage to check, config, status, and root commands early
- [+] Implement custom runtime error printing to stderr in check and status
- [+] Remove redundant SilenceUsage/SilenceErrors settings
- [+] Adjust SilenceErrors timing after runtime error checks