### PR TITLE
docs: add OpenCode integration with commands, agent guidelines, and config

### DIFF
--- a/.opencode/README.id.md
+++ b/.opencode/README.id.md
@@ -1,0 +1,9 @@
+# Perintah OpenCode
+
+[![Read in English](https://img.shields.io/badge/🇬🇧-Read%20in%20English-blue)](README.md)
+
+Direktori ini berisi perintah OpenCode khusus proyek untuk repositori nawala-checker.
+
+## Perintah yang Tersedia
+
+- `sync-docs`: Sinkronkan semua sumber dokumentasi saat membuat perubahan pada kodebasis nawala-checker

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -1,0 +1,9 @@
+# OpenCode Commands
+
+[![Baca dalam Bahasa Indonesia](https://img.shields.io/badge/🇮🇩-Baca%20dalam%20Bahasa%20Indonesia-red)](README.id.md)
+
+This directory contains project-specific OpenCode commands for the nawala-checker repository.
+
+## Available Commands
+
+- `sync-docs`: Synchronize all documentation sources when making changes to the nawala-checker codebase

--- a/.opencode/command/sync-docs.md
+++ b/.opencode/command/sync-docs.md
@@ -74,7 +74,12 @@ Since this project maintains both English and Indonesian documentation:
 
 Use conventional commit format:
 ```
-docs: sync documentation for [feature/fix description]
+docs: sync documentation for [description]
+
+- [+] Update README.md with changes
+- [+] Update GoDoc in docs.go
+- [+] Add/modify examples if needed
+- [+] Update CLI usage text
 ```
 
 ## Verification Checklist

--- a/.opencode/command/sync-docs.md
+++ b/.opencode/command/sync-docs.md
@@ -1,0 +1,86 @@
+# sync-docs
+
+Synchronize all documentation sources when making changes to the nawala-checker codebase. This command ensures consistency across multilingual documentation, GoDoc, examples, and CLI usage text.
+
+## When to Run
+
+Run this command when your changes involve:
+- New features or API changes
+- Modified existing behavior
+- Public interface updates
+- CLI command additions/modifications
+
+## Documentation Sources to Sync
+
+### 1. Primary Documentation Files
+- `README.md` - English documentation (primary)
+- `README.id.md` - Indonesian documentation (localized)
+
+### 2. Package-Level GoDoc
+- `src/nawala/docs.go` - Core SDK package documentation
+- `internal/cli/docs.go` - CLI package documentation
+
+### 3. Code Examples
+- `examples/` directory - Executable examples that demonstrate usage
+
+### 4. CLI Usage Text
+- `internal/cli/usage/` directory - Embedded CLI help text
+
+## Sync Process
+
+### Step 1: Identify Changes
+Review your code changes to determine what documentation needs updating:
+- New configuration options?
+- Changed function signatures?
+- New CLI commands or flags?
+- Modified behavior or error conditions?
+
+### Step 2: Update README Files
+Update both language versions:
+```bash
+# Edit README.md (English)
+# Edit README.id.md (Indonesian - maintain consistency)
+```
+
+### Step 3: Update GoDoc
+Ensure package documentation reflects new/changed APIs:
+```bash
+# Edit src/nawala/docs.go for SDK changes
+# Edit internal/cli/docs.go for CLI changes
+```
+
+### Step 4: Update Examples
+Add or modify examples in `examples/` directory to demonstrate new features.
+
+### Step 5: Update CLI Usage
+For CLI changes, update embedded usage text in `internal/cli/usage/`.
+
+### Step 6: Verify Consistency
+Run tests and ensure all documentation sources are technically accurate:
+```bash
+make test-verbose
+make build
+# Test CLI help: ./bin/nawala --help
+```
+
+## Multilingual Requirements
+
+Since this project maintains both English and Indonesian documentation:
+- Keep technical accuracy consistent between languages
+- Update both README files simultaneously
+- Maintain the same structure and examples in both languages
+
+## Commit Message
+
+Use conventional commit format:
+```
+docs: sync documentation for [feature/fix description]
+```
+
+## Verification Checklist
+
+- [ ] README.md updated with new features/changes
+- [ ] README.id.md updated (Indonesian)
+- [ ] GoDoc in docs.go files updated
+- [ ] Examples directory updated if needed
+- [ ] CLI usage text updated for CLI changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,167 @@
+# AGENTS.md - Nawala Checker Development Guidelines
+
+This document provides comprehensive guidelines for agentic coding assistants working on the nawala-checker codebase. It covers linting, testing, code style, and development practices.
+
+## Lint/Test Commands
+
+### Testing Commands
+- `make test` - Run all tests with race detector (mirrors CI)
+- `make test-verbose` - Run tests with verbose output and race detector
+- `make test-cover` - Run tests with coverage report and race detector, writes to `coverage.txt`
+- `make test-short` - Run unit tests only (skip live DNS tests)
+- `go test -race -run TestSpecificFunction ./src/nawala/...` - Run a single test function
+- `go test -race -run TestSpecificFunction$ ./src/nawala/...` - Run exactly one test function (with $ anchor)
+- `go test -race -run "TestCheck.*" ./src/nawala/...` - Run tests matching a pattern
+
+### Linting and Formatting
+- `go vet ./...` - Run go vet (static analysis)
+- `gofmt -s -w .` - Format code with gofmt (simplify and write)
+- `gofmt -d .` - Show formatting differences without modifying files
+
+### Coverage Analysis
+- `go tool cover -html=coverage.txt` - View coverage report in browser
+- `go tool cover -func=coverage.txt` - Show coverage percentages per function
+
+## Code Style Guidelines
+
+### General Principles
+- **GoDoc Comments**: Use GoDoc comments for all exported functions, types, and methods. Follow standard Go documentation conventions.
+- **Idiomatic Go**: Follow effective Go patterns and standard library conventions.
+- **Functional Options**: All configuration uses the functional options pattern defined in `option.go`.
+- **Context-first**: All I/O-performing methods accept `context.Context` as the first parameter.
+- **Typed Errors**: Use sentinel errors with `errors.Is()` and `errors.As()` for error checking.
+
+### Imports
+```go
+import (
+    "context"
+    "errors"
+    "fmt"
+    "time"
+
+    "github.com/miekg/dns"
+    "github.com/stretchr/testify/assert"
+)
+```
+- Standard library imports first, grouped by blank lines
+- Third-party imports second, alphabetically sorted
+- Local imports (if any) last
+
+### Naming Conventions
+- **Exported functions/types**: PascalCase (e.g., `NewChecker`, `WithTimeout`)
+- **Unexported functions/types**: camelCase (e.g., `queryWithRetries`, `defaultServers`)
+- **Constants**: PascalCase for exported, camelCase for unexported
+- **Variables**: camelCase throughout
+- **Test functions**: `TestFunctionName` or `TestFunctionName_Scenario`
+
+### Error Handling
+- Use sentinel errors defined in `errors.go`:
+  - `ErrNoDNSServers`
+  - `ErrAllDNSFailed`
+  - `ErrInvalidDomain`
+  - `ErrDNSTimeout`
+  - `ErrInternalPanic`
+  - `ErrNXDOMAIN`
+  - `ErrQueryRejected`
+
+- Error checking patterns:
+```go
+if errors.Is(err, ErrInvalidDomain) {
+    // handle invalid domain
+}
+```
+
+- Wrap errors with context when appropriate:
+```go
+return fmt.Errorf("failed to query %s: %w", domain, err)
+```
+
+### Types and Structs
+- Define clear, minimal struct types in `types.go`
+- Use meaningful field names with proper JSON tags when needed
+- Implement interfaces cleanly (e.g., `Cache` interface)
+
+### Constants
+- Group related constants together
+- Use meaningful names with units when applicable:
+```go
+const (
+    defaultTimeout     = 5 * time.Second
+    defaultRetries     = 2
+    defaultCacheTTL    = 5 * time.Minute
+    defaultConcurrency = 100
+    defaultEDNS0Size   = 1232
+)
+```
+
+### Functions and Methods
+- Keep functions focused and single-purpose
+- Use early returns to reduce nesting
+- Handle panics gracefully in goroutines with recover
+
+### Testing Patterns
+- Use `testify/assert` and `testify/require` for assertions
+- Table-driven tests for multiple test cases:
+```go
+func TestIsValidDomain(t *testing.T) {
+    tests := []struct {
+        name   string
+        domain string
+        want   bool
+    }{
+        {"valid .com", "example.com", true},
+        {"invalid empty", "", false},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            assert.Equal(t, tt.want, IsValidDomain(tt.domain))
+        })
+    }
+}
+```
+
+- Test both success and error cases
+- Use `t.Parallel()` for independent tests
+- Mock external dependencies when possible
+
+### Project Structure
+
+```
+nawala-checker/
+├── .github/            # CI workflows and Dependabot configuration
+├── cmd/
+│   └── nawala/         # CLI entry point
+├── examples/           # Runnable usage examples (basic, custom, status)
+├── internal/
+│   └── cli/            # CLI package (commands, config, output)
+├── Makefile            # Build and test shortcuts
+└── src/
+    └── nawala/         # Core SDK package (checker, cache, DNS, options, types)
+```
+
+### Security Considerations
+- Never log or cache sensitive information
+- Use timeout contexts for all network operations
+- Validate input domains before processing
+- Handle TLS connections securely (configurable skip verification for testing only)
+
+### Performance Guidelines
+- Use buffered channels for concurrency control
+- Implement proper connection pooling for TCP/TLS
+- Cache results with configurable TTL
+- Avoid unnecessary allocations in hot paths
+
+### CI/CD Integration
+- All changes must pass `go vet` and tests with race detection
+- Maintain or improve test coverage
+- Update documentation for API changes
+- Test across multiple Go versions (1.25.6+)
+
+### Dependencies
+- Minimize third-party dependencies
+- Use only well-maintained, security-audited packages
+- Pin versions in `go.mod` appropriately
+- Update dependencies regularly via Dependabot
+
+This document should be updated when development practices change. Always run `make test-cover` before submitting changes to ensure quality and coverage requirements are met.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "tools": {
+    "todowrite": true,
+    "todoread": true,
+    "question": true
+  },
+  "mcp": {
+    "gopls": {
+      "type": "local",
+      "command": [
+        "gopls",
+        "mcp"
+      ],
+      "environment": {
+        "GOPLS_MCP_PORT": "8096",
+        "GOPLS_MCP_HOST": "localhost"
+      },
+      "enabled": true
+    },
+    "deepwiki": {
+      "type": "remote",
+      "url": "https://mcp.deepwiki.com/mcp",
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
- [+] Create .opencode/README.md and README.id.md for multilingual command docs
- [+] Add .opencode/command/sync-docs.md for documentation sync process
- [+] Introduce AGENTS.md with linting, testing, style, and development guidelines
- [+] Add opencode.json for tools, MCP servers (gopls, deepwiki) configuration