### PR TITLE
docs(examples): add streaming and connection pooling demos

### DIFF
--- a/examples/README.id.md
+++ b/examples/README.id.md
@@ -21,6 +21,8 @@ pemeriksa pemblokiran domain berbasis DNS untuk filter DNS ISP Indonesia
 | [`custom/`](custom/main.go) | Konfigurasi lanjutan: server kustom, timeout, percobaan ulang, caching, dan kunci cache berbasis digest |
 | [`status/`](status/main.go) | Pantau kesehatan dan latensi server DNS |
 | [`hotreload/`](hotreload/main.go) | Perbarui server DNS dengan aman secara konkurensi saat pemeriksaan berjalan |
+| [`streaming/`](streaming/main.go) | Pemeriksaan domain dengan memori konstan menggunakan API CheckStream |
+| [`pooling/`](pooling/main.go) | Pooling koneksi TCP/TLS untuk performa yang lebih baik |
 
 ## Prasyarat
 
@@ -48,6 +50,8 @@ go run ./examples/basic
 go run ./examples/custom
 go run ./examples/status
 go run ./examples/hotreload
+go run ./examples/streaming
+go run ./examples/pooling
 ```
 
 ---
@@ -318,3 +322,127 @@ server DNS dan kata kuncinya di latar belakang.
   memastikan kode tidak pernah panic pada *race condition*.
 - Anda dapat sepenuhnya menimpa properti server yang ada (seperti `Keyword`
   atau `QueryType`) jika meneruskan konfigurasi server dengan `Address` yang identik.
+
+---
+
+## `streaming` — Pemeriksaan Domain dengan Memori Konstan
+
+[`streaming/main.go`](streaming/main.go) mendemonstrasikan API `CheckStream` untuk
+memproses daftar domain besar dengan penggunaan memori konstan, terlepas dari ukuran input.
+
+```go
+c := nawala.New()
+
+// Buat kanal bidirectional untuk streaming.
+in := make(chan string)
+out := make(chan nawala.Result, c.Concurrency())
+
+// Beri makan domain ke kanal input.
+go func() {
+    defer close(in)
+    domains := []string{"google.com", "reddit.com", "github.com"}
+    for _, domain := range domains {
+        in <- domain
+    }
+}()
+
+// Proses hasil saat tiba.
+go func() {
+    for result := range out {
+        status := "tidak diblokir"
+        if result.Blocked {
+            status = "DIBLOKIR"
+        }
+        fmt.Printf("  %-20s %s\n", result.Domain, status)
+    }
+}()
+
+// Lakukan pemeriksaan streaming.
+err := c.CheckStream(ctx, nawala.Stream{In: in, Out: out})
+```
+
+**Output yang diharapkan** (dari jaringan Indonesia):
+
+```
+=== Nawala DNS Streaming Check ===
+Processing 6 domains with constant memory usage...
+
+  exam_ple.com         error: nawala: nxdomain: domain does not exist (NXDOMAIN) (server: 180.131.144.144)
+  google.com           tidak diblokir (server: 180.131.144.144)
+  reddit.com           DIBLOKIR (server: 180.131.144.144)
+  github.com           tidak diblokir (server: 180.131.144.144)
+  stackoverflow.com    tidak diblokir (server: 180.131.144.144)
+  youtube.com          tidak diblokir (server: 180.131.144.144)
+
+Streaming check completed successfully!
+```
+
+**Yang ditunjukkan contoh ini:**
+
+- `CheckStream` memproses domain dari kanal input dan mengirim hasil ke kanal output
+- Penggunaan memori tetap konstan terlepas dari jumlah domain — cocok untuk jutaan domain
+- Hasil tiba secara asinkron saat pemeriksaan selesai, memungkinkan pemrosesan real-time
+- Penutupan kanal input menandakan akhir stream domain
+- Buffering kanal output mencegah blocking dengan `c.Concurrency()` sebagai ukuran buffer
+
+---
+
+## `pooling` — Pooling Koneksi TCP/TLS
+
+[`pooling/main.go`](pooling/main.go) menunjukkan cara mengaktifkan pooling koneksi TCP
+untuk performa yang lebih baik dengan koneksi persisten ke server DNS.
+
+```go
+c := nawala.New(
+    // Gunakan transport TCP untuk reuse koneksi.
+    nawala.WithProtocol("tcp"),
+
+    // Aktifkan pooling koneksi (ukuran menyesuaikan ke min(concurrency, 10)).
+    nawala.WithKeepAlive(0),
+
+    // Konfigurasikan server DNS yang mendukung TCP.
+    nawala.WithServers([]nawala.DNSServer{{
+        Address:   "8.8.8.8", // Google Public DNS over TCP
+        Keyword:   "blocked",
+        QueryType: "A",
+    }}),
+)
+
+// Periksa domain - koneksi di-pool dan digunakan kembali.
+results, err := c.Check(ctx, "google.com", "github.com")
+
+// Bersihkan pool koneksi saat selesai.
+c.Close()
+```
+
+**Output yang diharapkan** (menggunakan server TCP mock):
+
+```
+=== Nawala DNS TCP Connection Pooling ===
+Checking 4 domains using TCP with connection pooling on mock server...
+
+First batch (connection establishment):
+  example.com          tidak diblokir (server: 127.0.0.1:xxxxx)
+  test.com             tidak diblokir (server: 127.0.0.1:xxxxx)
+  demo.com             tidak diblokir (server: 127.0.0.1:xxxxx)
+  sample.com           tidak diblokir (server: 127.0.0.1:xxxxx)
+
+Second batch (connection reuse from pool):
+  example.com          tidak diblokir (server: 127.0.0.1:xxxxx)
+  test.com             tidak diblokir (server: 127.0.0.1:xxxxx)
+  demo.com             tidak diblokir (server: 127.0.0.1:xxxxx)
+  sample.com           tidak diblokir (server: 127.0.0.1:xxxxx)
+
+Connection pooling example completed!
+Note: Performance improvement is most noticeable with DNS over TLS (DoT)
+and servers that support persistent TCP connections.
+```
+
+**Yang ditunjukkan contoh ini:**
+
+- `WithKeepAlive(poolSize)` mengaktifkan pooling koneksi untuk protokol TCP/TCP-TLS
+- Ukuran pool `0` menggunakan default cerdas: `min(concurrency, 10)`
+- Koneksi secara otomatis digunakan kembali, mengurangi overhead handshake
+- Koneksi yang stale secara transparan di-redial saat error (EOF, timeout)
+- `c.Close()` menguras koneksi idle untuk cleanup yang benar
+- Paling bermanfaat dengan server DoT (RFC 7858) dan resolver DNS TCP modern

--- a/examples/README.id.md
+++ b/examples/README.id.md
@@ -383,6 +383,7 @@ Streaming check completed successfully!
 - Penggunaan memori tetap konstan terlepas dari jumlah domain — cocok untuk jutaan domain
 - Hasil tiba secara asinkron saat pemeriksaan selesai, memungkinkan pemrosesan real-time
 - Penutupan kanal input menandakan akhir stream domain
+- Kanal output ditutup setelah pemrosesan selesai dan hasil dikumpulkan dan diurutkan untuk tampilan yang konsisten
 - Buffering kanal output mencegah blocking dengan `c.Concurrency()` sebagai ukuran buffer
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,8 @@ DNS-based domain blocking checker for Indonesian ISP DNS filters
 | [`custom/`](custom/main.go) | Advanced configuration: custom servers, timeouts, retries, caching, and digest-based cache keys |
 | [`status/`](status/main.go) | Monitor DNS server health and latency |
 | [`hotreload/`](hotreload/main.go) | Safely update DNS servers while concurrent checks are running |
+| [`streaming/`](streaming/main.go) | Constant-memory domain checking with CheckStream API |
+| [`pooling/`](pooling/main.go) | TCP/TLS connection pooling for improved performance |
 
 ## Prerequisites
 
@@ -48,6 +50,8 @@ go run ./examples/basic
 go run ./examples/custom
 go run ./examples/status
 go run ./examples/hotreload
+go run ./examples/streaming
+go run ./examples/pooling
 ```
 
 ---
@@ -320,3 +324,127 @@ their keywords.
   ensuring it never panics on race conditions.
 - You can completely overwrite an existing server's properties (like `Keyword`
   or `QueryType`) if you pass a server config with an identical `Address`.
+
+---
+
+## `streaming` — Constant-Memory Domain Checking
+
+[`streaming/main.go`](streaming/main.go) demonstrates the `CheckStream` API for
+processing large domain lists with constant memory usage, regardless of input size.
+
+```go
+c := nawala.New()
+
+// Create bidirectional channels for streaming.
+in := make(chan string)
+out := make(chan nawala.Result, c.Concurrency())
+
+// Feed domains to input channel.
+go func() {
+    defer close(in)
+    domains := []string{"google.com", "reddit.com", "github.com"}
+    for _, domain := range domains {
+        in <- domain
+    }
+}()
+
+// Process results as they arrive.
+go func() {
+    for result := range out {
+        status := "not blocked"
+        if result.Blocked {
+            status = "BLOCKED"
+        }
+        fmt.Printf("  %-20s %s\n", result.Domain, status)
+    }
+}()
+
+// Perform streaming check.
+err := c.CheckStream(ctx, nawala.Stream{In: in, Out: out})
+```
+
+**Expected output** (from an Indonesian network):
+
+```
+=== Nawala DNS Streaming Check ===
+Processing 6 domains with constant memory usage...
+
+  exam_ple.com         error: nawala: nxdomain: domain does not exist (NXDOMAIN) (server: 180.131.144.144)
+  google.com           not blocked (server: 180.131.144.144)
+  reddit.com           BLOCKED (server: 180.131.144.144)
+  github.com           not blocked (server: 180.131.144.144)
+  stackoverflow.com    not blocked (server: 180.131.144.144)
+  youtube.com          not blocked (server: 180.131.144.144)
+
+Streaming check completed successfully!
+```
+
+**What this demonstrates:**
+
+- `CheckStream` processes domains from an input channel and sends results to an output channel
+- Memory usage remains constant regardless of domain count — suitable for millions of domains
+- Results arrive asynchronously as checks complete, enabling real-time processing
+- Input channel closure signals end of domain stream
+- Output channel buffering prevents blocking with `c.Concurrency()` as buffer size
+
+---
+
+## `pooling` — TCP/TLS Connection Pooling
+
+[`pooling/main.go`](pooling/main.go) shows how to enable TCP connection pooling
+for improved performance with persistent connections to DNS servers.
+
+```go
+c := nawala.New(
+    // Use TCP transport for connection reuse.
+    nawala.WithProtocol("tcp"),
+
+    // Enable connection pooling (size auto-adjusts to min(concurrency, 10)).
+    nawala.WithKeepAlive(0),
+
+    // Configure a TCP-supporting DNS server.
+    nawala.WithServers([]nawala.DNSServer{{
+        Address:   "8.8.8.8", // Google Public DNS over TCP
+        Keyword:   "blocked",
+        QueryType: "A",
+    }}),
+)
+
+// Check domains - connections are pooled and reused.
+results, err := c.Check(ctx, "google.com", "github.com")
+
+// Clean up connection pools when done.
+c.Close()
+```
+
+**Expected output** (using mock TCP server):
+
+```
+=== Nawala DNS TCP Connection Pooling ===
+Checking 4 domains using TCP with connection pooling on mock server...
+
+First batch (connection establishment):
+  example.com          not blocked (server: 127.0.0.1:xxxxx)
+  test.com             not blocked (server: 127.0.0.1:xxxxx)
+  demo.com             not blocked (server: 127.0.0.1:xxxxx)
+  sample.com           not blocked (server: 127.0.0.1:xxxxx)
+
+Second batch (connection reuse from pool):
+  example.com          not blocked (server: 127.0.0.1:xxxxx)
+  test.com             not blocked (server: 127.0.0.1:xxxxx)
+  demo.com             not blocked (server: 127.0.0.1:xxxxx)
+  sample.com           not blocked (server: 127.0.0.1:xxxxx)
+
+Connection pooling example completed!
+Note: Performance improvement is most noticeable with DNS over TLS (DoT)
+and servers that support persistent TCP connections.
+```
+
+**What this demonstrates:**
+
+- `WithKeepAlive(poolSize)` enables connection pooling for TCP/TCP-TLS protocols
+- Pool size of `0` uses intelligent defaults: `min(concurrency, 10)`
+- Connections are automatically reused, reducing handshake overhead
+- Stale connections are transparently redialed on errors (EOF, timeouts)
+- `c.Close()` drains idle connections for proper cleanup
+- Most beneficial with DoT servers (RFC 7858) and modern TCP DNS resolvers

--- a/examples/README.md
+++ b/examples/README.md
@@ -385,6 +385,7 @@ Streaming check completed successfully!
 - Memory usage remains constant regardless of domain count — suitable for millions of domains
 - Results arrive asynchronously as checks complete, enabling real-time processing
 - Input channel closure signals end of domain stream
+- Output channel is closed after processing completes and results are collected and sorted for consistent display
 - Output channel buffering prevents blocking with `c.Concurrency()` as buffer size
 
 ---

--- a/examples/pooling/main.go
+++ b/examples/pooling/main.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 H0llyW00dzZ All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+// Package main demonstrates TCP/TLS connection pooling with the nawala checker SDK.
+//
+// This example shows how to enable keep-alive connection pooling for
+// improved performance with DNS over TCP/TLS servers.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"time"
+
+	"github.com/H0llyW00dzZ/nawala-checker/src/nawala"
+	"github.com/miekg/dns"
+)
+
+// startMockTCPServer starts a mock TCP DNS server that supports connection reuse
+func startMockTCPServer() (*dns.Server, string) {
+	// Create a TCP handler that responds to A queries
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+
+		// Add a simple A record response
+		if len(r.Question) > 0 && r.Question[0].Qtype == dns.TypeA {
+			rr, _ := dns.NewRR(fmt.Sprintf("%s 300 IN A 127.0.0.1", r.Question[0].Name))
+			m.Answer = append(m.Answer, rr)
+		}
+
+		w.WriteMsg(m)
+	})
+
+	// Find an available port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	addr := listener.Addr().String()
+	listener.Close()
+
+	// Start TCP server
+	server := &dns.Server{
+		Addr:    addr,
+		Net:     "tcp",
+		Handler: handler,
+	}
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			log.Printf("mock TCP server error: %v", err)
+		}
+	}()
+
+	// Give server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	return server, addr
+}
+
+func main() {
+	// Start a mock TCP DNS server for demonstration
+	mockServer, serverAddr := startMockTCPServer()
+	defer mockServer.Shutdown()
+
+	// Create a checker with TCP protocol and connection pooling enabled.
+	// Pool size defaults to min(concurrency, 10) = 10 for this example.
+	c := nawala.New(
+		// Use TCP transport for connection reuse demonstration.
+		nawala.WithProtocol("tcp"),
+
+		// Enable connection pooling with default size.
+		nawala.WithKeepAlive(0), // 0 means use default sizing
+
+		// Use our mock TCP server
+		nawala.WithServers([]nawala.DNSServer{
+			{
+				Address:   serverAddr, // Our mock TCP server
+				Keyword:   "blocked",  // Won't match our responses
+				QueryType: "A",
+			},
+		}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Domains to check - connection pooling will reuse TCP connections to our mock server.
+	domains := []string{
+		"example.com",
+		"test.com",
+		"demo.com",
+		"sample.com",
+	}
+
+	fmt.Println("=== Nawala DNS TCP Connection Pooling ===")
+	fmt.Printf("Checking %d domains using TCP with connection pooling on mock server...\n\n", len(domains))
+
+	// First check - establishes pooled connections.
+	fmt.Println("First batch (connection establishment):")
+	results1, err := c.Check(ctx, domains...)
+	if err != nil {
+		log.Fatalf("first check failed: %v", err)
+	}
+
+	for _, r := range results1 {
+		status := "not blocked"
+		if r.Blocked {
+			status = "BLOCKED"
+		}
+		if r.Error != nil {
+			status = fmt.Sprintf("error: %v", r.Error)
+		}
+		fmt.Printf("  %-20s %s (server: %s)\n", r.Domain, status, r.Server)
+	}
+
+	fmt.Println("\nSecond batch (connection reuse from pool):")
+	// Second check - reuses pooled connections for better performance.
+	results2, err := c.Check(ctx, domains...)
+	if err != nil {
+		log.Fatalf("second check failed: %v", err)
+	}
+
+	for _, r := range results2 {
+		status := "not blocked"
+		if r.Blocked {
+			status = "BLOCKED"
+		}
+		if r.Error != nil {
+			status = fmt.Sprintf("error: %v", r.Error)
+		}
+		fmt.Printf("  %-20s %s (server: %s)\n", r.Domain, status, r.Server)
+	}
+
+	// Clean up connection pools.
+	c.Close()
+
+	fmt.Println("\nConnection pooling example completed!")
+	fmt.Println("Note: Performance improvement is most noticeable with DNS over TLS (DoT)")
+	fmt.Println("and servers that support persistent TCP connections.")
+}

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 H0llyW00dzZ All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+// Package main demonstrates streaming domain checking with the nawala checker SDK.
+//
+// This example shows how to use CheckStream for constant-memory processing
+// of large domain lists, processing results as they arrive.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/H0llyW00dzZ/nawala-checker/src/nawala"
+)
+
+func main() {
+	// Create a checker with default Nawala DNS servers.
+	c := nawala.New()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Domains to check - can be millions with constant memory usage.
+	domains := []string{
+		"exam_ple.com",
+		"google.com",
+		"reddit.com",
+		"github.com",
+		"stackoverflow.com",
+		"youtube.com",
+	}
+
+	fmt.Println("=== Nawala DNS Streaming Check ===")
+	fmt.Printf("Processing %d domains with constant memory usage...\n\n", len(domains))
+
+	// Create bidirectional channels for streaming.
+	in := make(chan string)
+	out := make(chan nawala.Result, c.Concurrency())
+
+	// Start domain input goroutine.
+	go func() {
+		defer close(in)
+		for _, domain := range domains {
+			in <- domain
+		}
+	}()
+
+	// Start result processing goroutine.
+	go func() {
+		for result := range out {
+			status := "not blocked"
+			if result.Blocked {
+				status = "BLOCKED"
+			}
+			if result.Error != nil {
+				status = fmt.Sprintf("error: %v", result.Error)
+			}
+			fmt.Printf("  %-20s %s (server: %s)\n", result.Domain, status, result.Server)
+		}
+	}()
+
+	// Perform streaming check.
+	err := c.CheckStream(ctx, nawala.Stream{In: in, Out: out})
+	if err != nil {
+		log.Fatalf("streaming check failed: %v", err)
+	}
+
+	fmt.Println("\nStreaming check completed successfully!")
+}

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"time"
 
 	"github.com/H0llyW00dzZ/nawala-checker/src/nawala"
@@ -50,24 +51,36 @@ func main() {
 		}
 	}()
 
-	// Start result processing goroutine.
-	go func() {
-		for result := range out {
-			status := "not blocked"
-			if result.Blocked {
-				status = "BLOCKED"
-			}
-			if result.Error != nil {
-				status = fmt.Sprintf("error: %v", result.Error)
-			}
-			fmt.Printf("  %-20s %s (server: %s)\n", result.Domain, status, result.Server)
-		}
-	}()
-
 	// Perform streaming check.
 	err := c.CheckStream(ctx, nawala.Stream{In: in, Out: out})
 	if err != nil {
 		log.Fatalf("streaming check failed: %v", err)
+	}
+
+	// Close output channel after CheckStream completes to signal end of results.
+	close(out)
+
+	// Collect and print all results.
+	var results []nawala.Result
+	for result := range out {
+		results = append(results, result)
+	}
+
+	// Sort results by domain for consistent output.
+	// (In practice, streaming results arrive in arbitrary order)
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Domain < results[j].Domain
+	})
+
+	for _, result := range results {
+		status := "not blocked"
+		if result.Blocked {
+			status = "BLOCKED"
+		}
+		if result.Error != nil {
+			status = fmt.Sprintf("error: %v", result.Error)
+		}
+		fmt.Printf("  %-20s %s (server: %s)\n", result.Domain, status, result.Server)
 	}
 
 	fmt.Println("\nStreaming check completed successfully!")


### PR DESCRIPTION
- [+] Update README.md and README.id.md with new examples table entries, run commands, and detailed sections including code snippets and outputs
- [+] Add examples/streaming/main.go demonstrating CheckStream API for constant-memory processing of large domain lists
- [+] Add examples/pooling/main.go demonstrating TCP/TLS connection pooling with keep-alive and mock server for reuse