### PR TITLE
refactor(tests): extract shared helpers to package-level helper_test.go files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,7 @@ func TestIsValidDomain(t *testing.T) {
 - Test both success and error cases
 - Use `t.Parallel()` for independent tests
 - Mock external dependencies when possible
+- Use `helper_test.go` files to share common test helpers (e.g., DNS server setups) across test files in the same package to avoid duplication
 
 ### Project Structure
 

--- a/internal/cli/check_test.go
+++ b/internal/cli/check_test.go
@@ -8,34 +8,12 @@ package cli
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/miekg/dns"
-	"github.com/spf13/cobra"
 )
-
-// collectDomains is a helper wrapper for tests to consume streamDomains into a slice.
-func collectDomains(args []string, filePath string) ([]string, error) {
-	ctx := context.Background()
-	in := make(chan string)
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- streamDomains(ctx, args, filePath, in)
-	}()
-
-	var domains []string
-	for d := range in {
-		domains = append(domains, d)
-	}
-
-	return domains, <-errCh
-}
 
 func TestCollectDomains_ArgsOnly(t *testing.T) {
 	domains, err := collectDomains([]string{"a.com", "b.com"}, "")
@@ -258,19 +236,6 @@ func TestCollectDomains_IDNAConversion(t *testing.T) {
 	})
 }
 
-// newCheckCmd creates a fresh check command for isolated testing.
-func newCheckCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:  "check [domains...]",
-		Args: cobra.ArbitraryArgs,
-		RunE: runCheck,
-	}
-	cmd.Flags().StringP("file", "f", "", "path to a .txt file with one domain per line")
-	cmd.Flags().StringP("output", "o", "", "write results to a file instead of stdout")
-	cmd.Flags().StringSlice("format", []string{"text"}, "output format (text, json, html, xlsx)")
-	return cmd
-}
-
 func TestRunCheck_NoDomains(t *testing.T) {
 	saved := configPath
 	configPath = ""
@@ -375,34 +340,6 @@ func TestRunCheck_NoServers(t *testing.T) {
 	}
 }
 
-func createMockDNSServer(t *testing.T) (string, func()) {
-	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
-	if err != nil {
-		t.Fatal(err)
-	}
-	done := make(chan struct{})
-	go func() {
-		buf := make([]byte, 512)
-		for {
-			n, addr, err := conn.ReadFromUDP(buf)
-			if err != nil {
-				close(done)
-				return
-			}
-			if n >= 12 {
-				// Create a valid DNS response (Standard query response, No error)
-				resp := append([]byte(nil), buf[:n]...) // copy request
-				resp[2] |= 0x80                         // Set QR bit (Response)
-				_, _ = conn.WriteToUDP(resp, addr)
-			}
-		}
-	}()
-	return conn.LocalAddr().String(), func() {
-		_ = conn.Close()
-		<-done
-	}
-}
-
 func TestRunCheck_Success(t *testing.T) {
 	mockAddr, cleanup := createMockDNSServer(t)
 	defer cleanup()
@@ -454,24 +391,6 @@ func TestRunCheck_MultipleFormatFlags(t *testing.T) {
 	}
 }
 
-// collectDomainsCtx is like collectDomains but accepts a context,
-// enabling tests for context-cancellation paths.
-func collectDomainsCtx(ctx context.Context, args []string, filePath string) ([]string, error) {
-	in := make(chan string)
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- streamDomains(ctx, args, filePath, in)
-	}()
-
-	var domains []string
-	for d := range in {
-		domains = append(domains, d)
-	}
-
-	return domains, <-errCh
-}
-
 // TestCollectDomains_ContextCancelledDuringArgs covers the ctx.Err() check
 // inside the positional-args loop of streamDomains (check.go line 140-142).
 func TestCollectDomains_ContextCancelledDuringArgs(t *testing.T) {
@@ -506,56 +425,6 @@ func TestCollectDomains_ContextCancelledDuringFileScan(t *testing.T) {
 	if err != context.Canceled {
 		t.Errorf("expected context.Canceled, got: %v", err)
 	}
-}
-
-// createSlowDNSServer starts a proper miekg/dns server that delays before
-// responding, used to guarantee context-deadline expiration during a DNS query.
-// Uses dns.Server for cross-platform reliability (matching the SDK internal tests).
-func createSlowDNSServer(t *testing.T, delay time.Duration) (string, func()) {
-	t.Helper()
-
-	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		time.Sleep(delay)
-		m := new(dns.Msg)
-		m.SetReply(r)
-		m.Answer = append(m.Answer, &dns.A{
-			Hdr: dns.RR_Header{
-				Name:   r.Question[0].Name,
-				Rrtype: dns.TypeA,
-				Class:  dns.ClassINET,
-				Ttl:    60,
-			},
-			A: net.ParseIP("93.184.216.34"),
-		})
-		_ = w.WriteMsg(m)
-	})
-
-	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	server := &dns.Server{
-		PacketConn: pc,
-		Handler:    handler,
-	}
-
-	started := make(chan error, 1)
-	go func() {
-		server.NotifyStartedFunc = func() { started <- nil }
-		if err := server.ActivateAndServe(); err != nil {
-			select {
-			case started <- err:
-			default:
-			}
-		}
-	}()
-
-	if err := <-started; err != nil {
-		t.Fatal(err)
-	}
-
-	return pc.LocalAddr().String(), func() { _ = server.Shutdown() }
 }
 
 // TestRunCheck_CheckerError covers the checkErrCh error-wrapping path

--- a/internal/cli/helper_test.go
+++ b/internal/cli/helper_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 H0llyW00dzZ All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+package cli
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/spf13/cobra"
+)
+
+// collectDomains is a helper wrapper for tests to consume streamDomains into a slice.
+func collectDomains(args []string, filePath string) ([]string, error) {
+	ctx := context.Background()
+	in := make(chan string)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- streamDomains(ctx, args, filePath, in)
+	}()
+
+	var domains []string
+	for d := range in {
+		domains = append(domains, d)
+	}
+
+	return domains, <-errCh
+}
+
+// newCheckCmd creates a fresh check command for isolated testing.
+func newCheckCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "check [domains...]",
+		Args: cobra.ArbitraryArgs,
+		RunE: runCheck,
+	}
+	cmd.Flags().StringP("file", "f", "", "path to a .txt file with one domain per line")
+	cmd.Flags().StringP("output", "o", "", "write results to a file instead of stdout")
+	cmd.Flags().StringSlice("format", []string{"text"}, "output format (text, json, html, xlsx)")
+	return cmd
+}
+
+func createMockDNSServer(t *testing.T) (string, func()) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		buf := make([]byte, 512)
+		for {
+			n, addr, err := conn.ReadFromUDP(buf)
+			if err != nil {
+				close(done)
+				return
+			}
+			if n >= 12 {
+				// Create a valid DNS response (Standard query response, No error)
+				resp := append([]byte(nil), buf[:n]...) // copy request
+				resp[2] |= 0x80                         // Set QR bit (Response)
+				_, _ = conn.WriteToUDP(resp, addr)
+			}
+		}
+	}()
+	return conn.LocalAddr().String(), func() {
+		_ = conn.Close()
+		<-done
+	}
+}
+
+// collectDomainsCtx is like collectDomains but accepts a context,
+// enabling tests for context-cancellation paths.
+func collectDomainsCtx(ctx context.Context, args []string, filePath string) ([]string, error) {
+	in := make(chan string)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- streamDomains(ctx, args, filePath, in)
+	}()
+
+	var domains []string
+	for d := range in {
+		domains = append(domains, d)
+	}
+
+	return domains, <-errCh
+}
+
+// createSlowDNSServer starts a proper miekg/dns server that delays before
+// responding, used to guarantee context-deadline expiration during a DNS query.
+// Uses dns.Server for cross-platform reliability (matching the SDK internal tests).
+func createSlowDNSServer(t *testing.T, delay time.Duration) (string, func()) {
+	t.Helper()
+
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		time.Sleep(delay)
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Answer = append(m.Answer, &dns.A{
+			Hdr: dns.RR_Header{
+				Name:   r.Question[0].Name,
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+				Ttl:    60,
+			},
+			A: net.ParseIP("93.184.216.34"),
+		})
+		_ = w.WriteMsg(m)
+	})
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := &dns.Server{
+		PacketConn: pc,
+		Handler:    handler,
+	}
+
+	started := make(chan error, 1)
+	go func() {
+		server.NotifyStartedFunc = func() { started <- nil }
+		if err := server.ActivateAndServe(); err != nil {
+			select {
+			case started <- err:
+			default:
+			}
+		}
+	}()
+
+	if err := <-started; err != nil {
+		t.Fatal(err)
+	}
+
+	return pc.LocalAddr().String(), func() { _ = server.Shutdown() }
+}

--- a/src/nawala/cache_key_test.go
+++ b/src/nawala/cache_key_test.go
@@ -68,27 +68,6 @@ func (ck *capturedKeyCache) snapshot() []string {
 	return out
 }
 
-// startSimpleDNSServer is a thin helper that starts a local DNS server
-// responding with a plain A record (1.2.3.4) for any query.
-func startSimpleDNSServer(t *testing.T) (addr string, cleanup func()) {
-	t.Helper()
-	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		m := new(dns.Msg)
-		m.SetReply(r)
-		m.Answer = append(m.Answer, &dns.A{
-			Hdr: dns.RR_Header{
-				Name:   r.Question[0].Name,
-				Rrtype: dns.TypeA,
-				Class:  dns.ClassINET,
-				Ttl:    60,
-			},
-			A: net.ParseIP("1.2.3.4"),
-		})
-		_ = w.WriteMsg(m)
-	})
-	return startTestDNSServer(t, handler)
-}
-
 // newCapturedCache returns a [cacheWrapper] backed by an in-memory cache that
 // records every key passed to Set. The returned *capturedKeyCache can be
 // snapshotted at any time to inspect the recorded keys.
@@ -144,7 +123,7 @@ func assertKeyFormat(t *testing.T, keys []string, hashFn func(string) string) {
 // (e.g., Redis, memcached), their keys cannot collide with keys generated
 // by this SDK.
 func TestCacheKeyPrefix(t *testing.T) {
-	addr, cleanup := startSimpleDNSServer(t)
+	addr, cleanup := startNormalDNSServer(t)
 	defer cleanup()
 
 	wrapped, captured := newCapturedCache(5 * time.Minute)
@@ -174,7 +153,7 @@ func TestCacheKeyPrefix(t *testing.T) {
 //
 //	nawala_checker:<hex-sha256>
 func TestWithDigestsSHA256(t *testing.T) {
-	addr, cleanup := startSimpleDNSServer(t)
+	addr, cleanup := startNormalDNSServer(t)
 	defer cleanup()
 
 	wrapped, captured := newCapturedCache(5 * time.Minute)
@@ -210,7 +189,7 @@ func TestWithDigestsSHA256(t *testing.T) {
 //
 //	nawala_checker:<hex-sha256d>
 func TestWithDigestsDoubleSHA256(t *testing.T) {
-	addr, cleanup := startSimpleDNSServer(t)
+	addr, cleanup := startNormalDNSServer(t)
 	defer cleanup()
 
 	wrapped, captured := newCapturedCache(5 * time.Minute)
@@ -375,7 +354,7 @@ func TestWithDigestsCacheHitDoubleSHA256(t *testing.T) {
 // a raw hex digest. This provides flexibility for advanced caching strategies
 // while maintaining the SDK's namespace prefix.
 func TestWithDigestsSubKey(t *testing.T) {
-	addr, cleanup := startSimpleDNSServer(t)
+	addr, cleanup := startNormalDNSServer(t)
 	defer cleanup()
 
 	// Digest function that adds a sub-key prefix.

--- a/src/nawala/checker_internal_test.go
+++ b/src/nawala/checker_internal_test.go
@@ -26,51 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// startBlockingDNSServer starts a local DNS server that responds with a CNAME
-// to "internetpositif.id." to simulate Nawala blocking behavior.
-func startBlockingDNSServer(t *testing.T) (string, func()) {
-	t.Helper()
-
-	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		m := new(dns.Msg)
-		m.SetReply(r)
-		m.Answer = append(m.Answer, &dns.CNAME{
-			Hdr: dns.RR_Header{
-				Name:   r.Question[0].Name,
-				Rrtype: dns.TypeCNAME,
-				Class:  dns.ClassINET,
-				Ttl:    60,
-			},
-			Target: "internetpositif.id.",
-		})
-		_ = w.WriteMsg(m)
-	})
-
-	return startTestDNSServer(t, handler)
-}
-
-// startNormalDNSServer starts a local DNS server that responds normally (not blocked).
-func startNormalDNSServer(t *testing.T) (string, func()) {
-	t.Helper()
-
-	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		m := new(dns.Msg)
-		m.SetReply(r)
-		m.Answer = append(m.Answer, &dns.A{
-			Hdr: dns.RR_Header{
-				Name:   r.Question[0].Name,
-				Rrtype: dns.TypeA,
-				Class:  dns.ClassINET,
-				Ttl:    60,
-			},
-			A: net.ParseIP("93.184.216.34"),
-		})
-		_ = w.WriteMsg(m)
-	})
-
-	return startTestDNSServer(t, handler)
-}
-
 func TestCheckConcurrent(t *testing.T) {
 	addr, cleanup := startNormalDNSServer(t)
 	defer cleanup()

--- a/src/nawala/dns_test.go
+++ b/src/nawala/dns_test.go
@@ -110,46 +110,6 @@ func TestContainsKeyword(t *testing.T) {
 	})
 }
 
-// startTestDNSServer starts a local DNS server that responds with configurable answers.
-// It returns the server address (ip:port) and a cleanup function.
-func startTestDNSServer(t *testing.T, handler dns.HandlerFunc) (string, func()) {
-	t.Helper()
-
-	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
-	require.NoError(t, err, "failed to listen")
-
-	server := &dns.Server{
-		PacketConn: pc,
-		Handler:    handler,
-	}
-
-	started := make(chan error, 1)
-	go func() {
-		server.NotifyStartedFunc = func() { started <- nil }
-		if err := server.ActivateAndServe(); err != nil {
-			// If the channel is not full, it means startup failed (NotifyStartedFunc didn't run).
-			// If full (or drained continuously), we try to send.
-			// Ideally, we only want to signal startup failure.
-			select {
-			case started <- err:
-			default:
-				// Startup already signaled (success) or channel full.
-				// Just log the error as it happened after start.
-				t.Logf("DNS server error: %v", err)
-			}
-		}
-	}()
-
-	if err := <-started; err != nil {
-		require.NoError(t, err, "failed to start server")
-	}
-	addr := pc.LocalAddr().String()
-
-	return addr, func() {
-		_ = server.Shutdown()
-	}
-}
-
 func TestQueryDNS(t *testing.T) {
 	t.Run("successful query", func(t *testing.T) {
 		handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {

--- a/src/nawala/helper_test.go
+++ b/src/nawala/helper_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 H0llyW00dzZ All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+package nawala
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+)
+
+// startTestDNSServer starts a local DNS server that responds with configurable answers.
+// It returns the server address (ip:port) and a cleanup function.
+func startTestDNSServer(t *testing.T, handler dns.HandlerFunc) (string, func()) {
+	t.Helper()
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to listen")
+
+	server := &dns.Server{
+		PacketConn: pc,
+		Handler:    handler,
+	}
+
+	started := make(chan error, 1)
+	go func() {
+		server.NotifyStartedFunc = func() { started <- nil }
+		if err := server.ActivateAndServe(); err != nil {
+			// If the channel is not full, it means startup failed (NotifyStartedFunc didn't run).
+			// If full (or drained continuously), we try to send.
+			// Ideally, we only want to signal startup failure.
+			select {
+			case started <- err:
+			default:
+				// Startup already signaled (success) or channel full.
+				// Just log the error as it happened after start.
+				t.Logf("DNS server error: %v", err)
+			}
+		}
+	}()
+
+	if err := <-started; err != nil {
+		require.NoError(t, err, "failed to start server")
+	}
+	addr := pc.LocalAddr().String()
+
+	return addr, func() {
+		_ = server.Shutdown()
+	}
+}
+
+// startBlockingDNSServer starts a local DNS server that responds with a CNAME
+// to "internetpositif.id." to simulate Nawala blocking behavior.
+func startBlockingDNSServer(t *testing.T) (string, func()) {
+	t.Helper()
+
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Answer = append(m.Answer, &dns.CNAME{
+			Hdr:    dns.RR_Header{Name: r.Question[0].Name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET},
+			Target: "internetpositif.id.",
+		})
+		_ = w.WriteMsg(m)
+	})
+
+	return startTestDNSServer(t, handler)
+}
+
+// startNormalDNSServer starts a local DNS server that responds normally (not blocked).
+func startNormalDNSServer(t *testing.T) (string, func()) {
+	t.Helper()
+
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Answer = append(m.Answer, &dns.A{
+			Hdr: dns.RR_Header{Name: r.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET},
+			A:   net.ParseIP("1.2.3.4"),
+		})
+		_ = w.WriteMsg(m)
+	})
+
+	return startTestDNSServer(t, handler)
+}


### PR DESCRIPTION
- [+] Document helper_test.go usage in AGENTS.md
- [+] Move CLI helpers (collectDomains, newCheckCmd, etc.) to internal/cli/helper_test.go
- [+] Move Nawala DNS helpers (startTestDNSServer, etc.) to src/nawala/helper_test.go
- [+] Remove duplicated helpers from cli/check_test.go and nawala/*_test.go files
- [+] Update test calls (e.g., startSimpleDNSServer → startNormalDNSServer)