### PR TITLE
docs: update MCP integration roadmap to include SDK support

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -591,7 +591,7 @@ make build
 
 - [ ] Tingkatkan `github.com/miekg/dns` ke v2 atau gunakan alternatif modern untuk meningkatkan kinerja dan fitur jaringan, karena implementasinya di Go dan efektivitasnya yang tinggi untuk jaringan.
 - [x] Implementasikan versi CLI (dibundel dalam repositori ini) untuk memeriksa domain langsung dari terminal tanpa perlu menulis kode Go.
-- [ ] Implementasikan versi server [MCP](https://modelcontextprotocol.io/docs/getting-started/intro) ([Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro)) (dibundel dalam repositori ini) untuk mengintegrasikan nawala-checker secara langsung dengan agen AI dan LLM.
+- [ ] Implementasikan dukungan [MCP](https://modelcontextprotocol.io/docs/getting-started/intro) ([Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro)) dengan versi SDK (helper untuk framework/tools AI agentic seperti [opencode](https://opencode.ai), [openclaw](https://openclaw.ai), [crush](https://github.com/charmbracelet/crush), dan lainnya) serta versi CLI/server (dibundel dalam repositori ini) untuk mengintegrasikan nawala-checker secara langsung dengan agen AI dan LLM melalui protokol MCP standar.
 - [ ] Implementasikan versi server [JSON-RPC 2.0](https://www.jsonrpc.org/specification) murni (dibundel dalam repositori ini) untuk integrasi lintas bahasa melalui stdio atau TCP, serupa cara kerja MCP namun menggunakan protokol kawat JSON-RPC standar.
 
 ## 📄 Lisensi

--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ make build
 
 - [ ] Upgrade `github.com/miekg/dns` to v2 or use a modern alternative for improved networking performance and features, due to its implementation in Go and its high effectiveness for networking.
 - [x] Implement a CLI version (bundled in this repository) for checking domains directly from the terminal without writing Go code.
-- [ ] Implement an [MCP](https://modelcontextprotocol.io/docs/getting-started/intro) ([Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro)) server version (bundled in this repository) for integrating nawala-checker directly with LLMs and AI agents.
+- [ ] Implement [MCP](https://modelcontextprotocol.io/docs/getting-started/intro) ([Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro)) support with both an SDK version (helpers for agentic AI frameworks/tools like [opencode](https://opencode.ai), [openclaw](https://openclaw.ai), [crush](https://github.com/charmbracelet/crush), and others) and a CLI/server version (bundled in this repository) for integrating nawala-checker directly with LLMs and AI agents via the standard MCP protocol.
 - [ ] Implement a pure [JSON-RPC 2.0](https://www.jsonrpc.org/specification) server version (bundled in this repository) for language-agnostic integration over stdio or TCP, similar in spirit to how MCP works but using the standard JSON-RPC wire protocol.
 
 ## 📄 License


### PR DESCRIPTION
- [+] Expand MCP todo in README.md to mention SDK helpers for AI frameworks like opencode, openclaw, crush
- [+] Apply equivalent update to MCP todo in Indonesian README.id.md